### PR TITLE
Add hooks and services

### DIFF
--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.4.5
-        version: 6.4.5(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.4.5)))
+        version: 6.4.5(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.4.5)))
       '@testing-library/react':
         specifier: ^15.0.6
         version: 15.0.7(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2301,6 +2301,9 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.12':
+    resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
 
   '@types/jsdom@20.0.1':
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
@@ -10302,7 +10305,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.5(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.4.5)))':
+  '@testing-library/jest-dom@6.4.5(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.4.5)))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.24.5
@@ -10314,6 +10317,7 @@ snapshots:
       redent: 3.0.0
     optionalDependencies:
       '@jest/globals': 29.7.0
+      '@types/jest': 29.5.12
       jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.4.5))
 
   '@testing-library/react@13.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -10412,6 +10416,12 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.12':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
+    optional: true
 
   '@types/jsdom@20.0.1':
     dependencies:

--- a/app/src/components/NotificationToast.tsx
+++ b/app/src/components/NotificationToast.tsx
@@ -24,7 +24,7 @@ const NotificationToast: React.FC<NotificationToastProps> = ({
   // Remove notification after TTL
   useEffect(() => {
     const timeoutRef = setTimeout(() => {
-      removeNotification(notification.id)
+      removeNotification(notification.id!)
     }, NOTIFICATION_TTL_MS)
 
     return () => clearTimeout(timeoutRef)
@@ -53,7 +53,7 @@ const NotificationToast: React.FC<NotificationToastProps> = ({
       </div>
 
       {/* Close Button */}
-      <button className="btn btn-ghost btn-xs" onClick={() => removeNotification(notification.id)}>
+      <button className="btn btn-ghost btn-xs" onClick={() => removeNotification(notification.id!)}>
         Close
       </button>
     </motion.div>

--- a/app/src/components/NotificationToast.tsx
+++ b/app/src/components/NotificationToast.tsx
@@ -24,7 +24,7 @@ const NotificationToast: React.FC<NotificationToastProps> = ({
   // Remove notification after TTL
   useEffect(() => {
     const timeoutRef = setTimeout(() => {
-      removeNotification(notification.id!)
+      removeNotification(notification.id)
     }, NOTIFICATION_TTL_MS)
 
     return () => clearTimeout(timeoutRef)
@@ -53,7 +53,7 @@ const NotificationToast: React.FC<NotificationToastProps> = ({
       </div>
 
       {/* Close Button */}
-      <button className="btn btn-ghost btn-xs" onClick={() => removeNotification(notification.id!)}>
+      <button className="btn btn-ghost btn-xs" onClick={() => removeNotification(notification.id)}>
         Close
       </button>
     </motion.div>

--- a/app/src/hooks/useChains.tsx
+++ b/app/src/hooks/useChains.tsx
@@ -1,6 +1,7 @@
 import { Chain } from '@/models/chain'
 import { NotificationSeverity } from '@/models/notification'
 import { Token } from '@/models/token'
+import { getChains } from '@/services/chains'
 import * as Sentry from '@sentry/nextjs'
 import { useCallback, useEffect, useState } from 'react'
 import useNotification from './useNotification'
@@ -23,13 +24,13 @@ const useChains = ({ supportedToken, supportedSourceChain, supportedDestChain }:
       setLoading(true)
       setError(null)
 
-      /* const loadedChains: Chain[] = await getChains({
+      const loadedChains: Chain[] = await getChains({
         token: supportedToken,
         sourceChain: supportedSourceChain,
         destChain: supportedDestChain,
-      }) // TODO change to chains service
+      })
 
-      setChains(loadedChains) */
+      setChains(loadedChains)
     } catch (err) {
       let errorMessage = 'An unknown error occurred'
       if (err instanceof Error) errorMessage = err.message
@@ -44,7 +45,7 @@ const useChains = ({ supportedToken, supportedSourceChain, supportedDestChain }:
     } finally {
       setLoading(false)
     }
-  }, [supportedToken, supportedSourceChain, supportedDestChain])
+  }, [supportedToken, supportedSourceChain, supportedDestChain, addNotification])
 
   useEffect(() => {
     fetchChains()

--- a/app/src/hooks/useChains.tsx
+++ b/app/src/hooks/useChains.tsx
@@ -1,0 +1,60 @@
+import { Chain } from '@/models/chain'
+import { NotificationSeverity } from '@/models/notification'
+import { Token } from '@/models/token'
+import * as Sentry from '@sentry/nextjs'
+import { useCallback, useEffect, useState } from 'react'
+import useNotification from './useNotification'
+
+interface Params {
+  supportedToken?: Token
+  supportedSourceChain?: Chain
+  supportedDestChain?: Chain
+}
+
+const useChains = ({ supportedToken, supportedSourceChain, supportedDestChain }: Params) => {
+  const { addNotification } = useNotification()
+
+  const [chains, setChains] = useState<Chain[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchChains = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      /* const loadedChains: Chain[] = await getChains({
+        token: supportedToken,
+        sourceChain: supportedSourceChain,
+        destChain: supportedDestChain,
+      }) // TODO change to chains service
+
+      setChains(loadedChains) */
+    } catch (err) {
+      let errorMessage = 'An unknown error occurred'
+      if (err instanceof Error) errorMessage = err.message
+
+      setError(errorMessage)
+      addNotification({
+        header: 'Error loading chains',
+        message: errorMessage,
+        severity: NotificationSeverity.ERROR,
+      })
+      Sentry.captureException(err)
+    } finally {
+      setLoading(false)
+    }
+  }, [supportedToken, supportedSourceChain, supportedDestChain])
+
+  useEffect(() => {
+    fetchChains()
+  }, [fetchChains])
+
+  return {
+    chains,
+    loading,
+    error,
+  }
+}
+
+export default useChains

--- a/app/src/hooks/usePastTransfers.tsx
+++ b/app/src/hooks/usePastTransfers.tsx
@@ -1,0 +1,50 @@
+import { NotificationSeverity } from '@/models/notification'
+import { Transfer } from '@/models/transfer'
+import { getPastTransfers } from '@/services/pastTransfers'
+import * as Sentry from '@sentry/nextjs'
+import { useCallback, useEffect, useState } from 'react'
+import useNotification from './useNotification'
+
+const usePastTransfers = (address?: string) => {
+  const { addNotification } = useNotification()
+
+  const [pastTransfers, setPastTransfers] = useState<Transfer[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchPastTransfers = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      const loadedTransfers: Transfer[] = await getPastTransfers(address)
+
+      setPastTransfers(loadedTransfers)
+    } catch (err) {
+      let errorMessage = 'An unknown error occurred'
+      if (err instanceof Error) errorMessage = err.message
+
+      setError(errorMessage)
+      addNotification({
+        header: 'Error loading past transfers',
+        message: errorMessage,
+        severity: NotificationSeverity.ERROR,
+      })
+      Sentry.captureException(err)
+    } finally {
+      setLoading(false)
+    }
+  }, [address, addNotification])
+
+  useEffect(() => {
+    fetchPastTransfers()
+  }, [fetchPastTransfers])
+
+  return {
+    pastTransfers,
+    loading,
+    error,
+  }
+}
+
+export default usePastTransfers

--- a/app/src/hooks/useTokens.tsx
+++ b/app/src/hooks/useTokens.tsx
@@ -1,0 +1,1 @@
+// TODO implement this hook. It is similar to useChains

--- a/app/src/models/notification.ts
+++ b/app/src/models/notification.ts
@@ -6,7 +6,7 @@ export enum NotificationSeverity {
 }
 
 export interface Notification {
-  id: number
+  id?: number
   severity?: NotificationSeverity
   header: string
   message?: string

--- a/app/src/models/notification.ts
+++ b/app/src/models/notification.ts
@@ -6,7 +6,7 @@ export enum NotificationSeverity {
 }
 
 export interface Notification {
-  id?: number
+  id: number
   severity?: NotificationSeverity
   header: string
   message?: string

--- a/app/src/models/transfer.ts
+++ b/app/src/models/transfer.ts
@@ -1,0 +1,14 @@
+import { Chain } from './chain'
+import { Token } from './token'
+
+// TODO: Update the interface once it is more clearly defined
+export interface Transfer {
+  id: string
+  txHashes: string[]
+  token: Token
+  sourceChain: Chain
+  destChain: Chain
+  amount: string
+  receiver: string
+  status: string
+}

--- a/app/src/services/chains.ts
+++ b/app/src/services/chains.ts
@@ -1,0 +1,35 @@
+import { Chain } from '@/models/chain'
+import { Token } from '@/models/token'
+
+interface Params {
+  /** Token to filter chains by. If provided, only chains that support this token will be returned */
+  token?: Token
+  /** Source chain to filter chains by. If provided, only chains that support this source chain will be returned */
+  sourceChain?: Chain
+  /** Destination chain to filter chains by. If provided, only chains that support this destination chain will be returned */
+  destChain?: Chain
+}
+
+/**
+ * Fetches a list of available blockchains for a transfer.
+ *
+ * @param filters - Filters to apply to the list of available blockchains. Contains the token, source chain, and destination chain.
+ * @returns A promise that resolves to a list of available blockchains for a transfer.
+ * @throws An error if the fetch request fails.
+ */
+export const getChains = async ({ token, sourceChain, destChain }: Params): Promise<Chain[]> => {
+  // add query params - TODO: Adjust when endpoint is defined
+  const searchParams = new URLSearchParams()
+  if (token) searchParams.append('token', token.id)
+  if (sourceChain) searchParams.append('sourceChain', sourceChain.id)
+  if (destChain) searchParams.append('destChain', destChain.id)
+
+  const response = await fetch('/api/chains?' + searchParams.toString()) // TODO: Add the correct endpoint
+
+  if (!response.ok)
+    throw new Error(`${response.status} ${response.statusText}: ${await response.text()}`)
+
+  const chains: Chain[] = await response.json()
+
+  return chains
+}

--- a/app/src/services/chains.ts
+++ b/app/src/services/chains.ts
@@ -18,7 +18,8 @@ interface Params {
  * @throws An error if the fetch request fails.
  */
 export const getChains = async ({ token, sourceChain, destChain }: Params): Promise<Chain[]> => {
-  // add query params - TODO: Adjust when endpoint is defined
+  // TODO: Adjust when endpoint is defined
+  // add query params
   const searchParams = new URLSearchParams()
   if (token) searchParams.append('token', token.id)
   if (sourceChain) searchParams.append('sourceChain', sourceChain.id)

--- a/app/src/services/pastTransfers.ts
+++ b/app/src/services/pastTransfers.ts
@@ -1,0 +1,24 @@
+import { Transfer } from '@/models/transfer'
+
+/**
+ * Fetches the finished transfers for a given address. Or for all addresses if no address is provided.
+ *
+ * @param address - The address to fetch the transfer history for.
+ * @returns A promise that resolves to the past transfers for the given address.
+ * @throws An error if the fetch request fails.
+ */
+export const getPastTransfers = async (address?: string): Promise<Transfer[]> => {
+  // TODO: adjust function parameters as needed once api works
+  // add query params
+  const searchParams = new URLSearchParams()
+  if (address) searchParams.append('address', address)
+
+  const response = await fetch('/api/past-transfers?' + searchParams.toString()) // TODO: Update the endpoint once it is defined
+
+  if (!response.ok)
+    throw new Error(`${response.status} ${response.statusText}: ${await response.text()}`)
+
+  const transfers: Transfer[] = await response.json()
+
+  return transfers
+}

--- a/app/src/store/notificationStore.ts
+++ b/app/src/store/notificationStore.ts
@@ -16,7 +16,9 @@ export const useNotificationStore = create<State>(set => ({
 
   // Actions
   addNotification: notification =>
-    set(state => ({ notifications: [...state.notifications, notification] })),
+    set(state => ({
+      notifications: [...state.notifications, { ...notification, id: state.notifications.length }], // override id
+    })),
 
   removeNotification: id =>
     set(state => ({

--- a/app/src/store/notificationStore.ts
+++ b/app/src/store/notificationStore.ts
@@ -6,7 +6,7 @@ interface State {
   notifications: Notification[]
 
   // Actions
-  addNotification: (notification: Notification) => void
+  addNotification: (notification: Omit<Notification, 'id'>) => void
   removeNotification: (id: number) => void
 }
 


### PR DESCRIPTION
This PR
- adds `useChains` and `usePastTransfers` hooks
- adds `chains` and `pastTransfers` services
- adds first draft of `transfer` model
- adds `useTokens` template that still needs to be implemented. As well as `tokens` service.

Note: To keep the PR smaller I will include `useOngoingTransfers`, `useTransfer` etc. in separat PRs.