### PR TITLE
fix: Convert amount to right decimal base

### DIFF
--- a/app/src/__tests__/Transfer.test.tsx
+++ b/app/src/__tests__/Transfer.test.tsx
@@ -1,6 +1,7 @@
 import { Direction, resolveDirection } from '@/services/transfer'
 import '@testing-library/jest-dom'
-import { AssetHub, Ethereum } from './testdata'
+import { AssetHub, Ethereum, WETH } from './testdata'
+import { convertAmount } from '@/utils/transfer'
 
 describe('Transfer', () => {
   it('direction ToEthereum', () => {
@@ -17,5 +18,13 @@ describe('Transfer', () => {
 
   it('direction WithinEthereum', () => {
     expect(resolveDirection(Ethereum, Ethereum)).toBe(Direction.WithinEthereum)
+  })
+})
+
+describe('Transfer', () => {
+  it('convert input amount to based amount', () => {
+    expect(convertAmount(1, WETH)).toBe(1000000000000000000)
+    expect(convertAmount(0.12, WETH)).toBe(120000000000000000)
+    expect(convertAmount(123, WETH)).toBe(123000000000000000000)
   })
 })

--- a/app/src/__tests__/Transfer.test.tsx
+++ b/app/src/__tests__/Transfer.test.tsx
@@ -23,8 +23,8 @@ describe('Transfer', () => {
 
 describe('Transfer', () => {
   it('convert input amount to based amount', () => {
-    expect(convertAmount(1, WETH)).toBe(1000000000000000000)
-    expect(convertAmount(0.12, WETH)).toBe(120000000000000000)
-    expect(convertAmount(123, WETH)).toBe(123000000000000000000)
+    expect(convertAmount(1, WETH)).toBe(BigInt(1000000000000000000))
+    expect(convertAmount(0.12, WETH)).toBe(BigInt(120000000000000000))
+    expect(convertAmount(123, WETH)).toBe(BigInt(123000000000000000000))
   })
 })

--- a/app/src/__tests__/testdata.ts
+++ b/app/src/__tests__/testdata.ts
@@ -1,4 +1,5 @@
 import { Chain, Network } from '@/models/chain'
+import { Token } from '@/models/token'
 
 export const Ethereum: Chain = {
   id: 'ethereum',
@@ -19,11 +20,12 @@ export const AssetHub: Chain = {
 
 export const testchains = [AssetHub, Ethereum]
 
-export const testTokens = [
-  {
-    id: 'weth',
-    name: 'Wrapped Ether',
-    symbol: 'wETH',
-    logoURI: 'https://ucarecdn.com/c01c9021-a497-41b5-8597-9ab4e71440c1/wrapped-eth.png',
-  },
-]
+export const WETH: Token = {
+  id: 'weth',
+  name: 'Wrapped Ether',
+  symbol: 'wETH',
+  logoURI: 'https://ucarecdn.com/c01c9021-a497-41b5-8597-9ab4e71440c1/wrapped-eth.png',
+  decimals: 18,
+}
+
+export const testTokens = [WETH]

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -16,13 +16,14 @@ import ValueInput from './ValueInput'
 import useEnvironment from '@/hooks/useEnvironment'
 import WalletButton from './WalletButton'
 import useWallet from '@/hooks/useWallet'
+import { convertAmount } from '@/utils/transfer'
 
 const Transfer: FC = () => {
   // Inputs
   const [sourceChain, setSourceChain] = useState<Chain | null>(null)
   const [destinationChain, setDestinationChain] = useState<Chain | null>(null)
   const [token, setToken] = useState<Token | null>(null)
-  const [amount, setAmount] = useState<number | null>(null)
+  const [inputAmount, setInputAmount] = useState<number | null>(null)
   const [manualRecipient, setManualRecipient] = useState<string>('')
   const [manualRecipientEnabled, setManualRecipientEnabled] = useState<boolean>(false)
 
@@ -48,6 +49,7 @@ const Transfer: FC = () => {
   const { environment, switchTo } = useEnvironment()
   const { transfer, isValid } = useTransfer()
   const recipient = manualRecipientEnabled ? manualRecipient : destinationWallet?.address
+  const amount = convertAmount(inputAmount, token)
 
   // functions
   const validate = () =>
@@ -113,8 +115,8 @@ const Transfer: FC = () => {
         <div>
           <span className="label label-text">Amount</span>
           <ValueInput
-            value={amount}
-            onChange={setAmount}
+            value={inputAmount}
+            onChange={setInputAmount}
             placeholder="0"
             disabled={!token}
             unit={token?.symbol}

--- a/app/src/hooks/useTransfer.tsx
+++ b/app/src/hooks/useTransfer.tsx
@@ -42,6 +42,7 @@ const useTransfer = () => {
     amount,
   }: TransferParams) => {
     let direction = resolveDirection(sourceChain, destinationChain)
+    let basedAmount = amount ** token.decimals
 
     switch (direction) {
       case Direction.ToPolkadot:

--- a/app/src/hooks/useTransfer.tsx
+++ b/app/src/hooks/useTransfer.tsx
@@ -15,7 +15,7 @@ interface TransferParams {
   token: Token
   destinationChain: Chain
   recipient: string
-  amount: number
+  amount: bigint
 }
 
 interface TransferValidationParams {
@@ -24,7 +24,7 @@ interface TransferValidationParams {
   token: Token | null
   destinationChain: Chain | null
   recipient?: string | null
-  amount: number | null
+  amount: bigint | null
 }
 
 /**
@@ -42,7 +42,6 @@ const useTransfer = () => {
     amount,
   }: TransferParams) => {
     let direction = resolveDirection(sourceChain, destinationChain)
-    let basedAmount = amount ** token.decimals
 
     switch (direction) {
       case Direction.ToPolkadot:

--- a/app/src/models/token.ts
+++ b/app/src/models/token.ts
@@ -3,5 +3,6 @@ export interface Token {
   id: string
   name: string
   logoURI: string
-  symbol?: string
+  symbol: string
+  decimals: number
 }

--- a/app/src/services/transfer.ts
+++ b/app/src/services/transfer.ts
@@ -50,7 +50,7 @@ export const toPolkadot = async (
   environment: Environment,
   signer: Signer,
   token: Token,
-  amount: number,
+  amount: bigint,
   destinationChain: Chain,
   recipient: string,
 ): Promise<void> => {
@@ -65,7 +65,7 @@ export const toPolkadot = async (
       recipient,
       tokenContract,
       destinationChain.chainId,
-      BigInt(amount),
+      amount,
       BigInt(0),
     )
     .then(plan => Snowbridge.toPolkadot.send(context, signer, plan))
@@ -95,7 +95,7 @@ export const toEthereum = async (
   sourceChain: Chain,
   sender: WalletOrKeypair,
   token: Token,
-  amount: number,
+  amount: bigint,
   recipient: string,
 ): Promise<void> => {
   const snowbridgeEnv = getEnvironment(environment)
@@ -103,7 +103,7 @@ export const toEthereum = async (
   const tokenContract = getErc20TokenContract(token, snowbridgeEnv)
 
   await Snowbridge.toEthereum
-    .validateSend(context, sender, sourceChain.chainId, recipient, tokenContract, BigInt(amount))
+    .validateSend(context, sender, sourceChain.chainId, recipient, tokenContract, amount)
     .then(plan => Snowbridge.toEthereum.send(context, sender, plan))
     .then(sent => trackToEthereum(context, sent))
     .then(res => console.log('Result:', res))

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -9,8 +9,8 @@ import { Token } from '@/models/token'
  * @param token - the token the amount is relative to
  * @returns the amount in the decimal base of the given token
  */
-export const convertAmount = (input: number | null, token: Token | null): number | null => {
-  if (!input || !token) return null
+export const convertAmount = (input: number | null, token: Token | null): bigint | null => {
+  if (input == null || !token) return null
 
-  return input * 10 ** token.decimals
+  return BigInt(input * 10 ** token.decimals)
 }

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -1,0 +1,16 @@
+import { Token } from '@/models/token'
+
+/**
+ * Convert a user given amount to the correct value that takes the token decimal in consideration
+ *
+ * E.g 1 WETH as input is converted to 1000000000000000000 given that WETH is an 18-decimal token.
+ *
+ * @param input - the input amount
+ * @param token - the token the amount is relative to
+ * @returns the amount in the decimal base of the given token
+ */
+export const convertAmount = (input: number | null, token: Token | null): number | null => {
+  if (!input || !token) return null
+
+  return input * 10 ** token.decimals
+}

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -1,13 +1,13 @@
 import { Token } from '@/models/token'
 
 /**
- * Convert a user given amount to the correct value that takes the token decimal in consideration
+ * Converts a user-specified amount to its corresponding value in the token's decimal base.
  *
- * E.g 1 WETH as input is converted to 1000000000000000000 given that WETH is an 18-decimal token.
+ * For example, if the input is "1 WETH" and given that WETH is an 18 decimals token, the function converts this to 1 * 10^18 = 1000000000000000000 (wei).
  *
- * @param input - the input amount
- * @param token - the token the amount is relative to
- * @returns the amount in the decimal base of the given token
+ * @param input - The amount specified by the user. For example, 1 WETH.
+ * @param token - The token object which includes its decimals property.
+ * @returns The amount in with the token's decimal base, or null if the input or token is not provided.
  */
 export const convertAmount = (input: number | null, token: Token | null): bigint | null => {
   if (input == null || !token) return null


### PR DESCRIPTION
Currently the app expects the input amount to be already provided with the right decimal base for the selected token.
In this PR, we change that so the user provides a user-facing amount (e.g. 1 WETH) and we convert it to the right decimal base for the selected token.


### Changes

 - Add `decimals` field to the `Token` type
 - Convert the input amount to the right value using `convertAmount`
 - Add unit tests