### PR TITLE
refacto ens fetch on transfer component

### DIFF
--- a/app/src/components/ChainSelect.tsx
+++ b/app/src/components/ChainSelect.tsx
@@ -44,10 +44,7 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
     const triggerRef = useRef<HTMLDivElement>(null)
     const dropdownRef = useRef<HTMLDivElement>(null)
     useOutsideClick(triggerRef, dropdownRef, () => setIsOpen(false))
-    const addressLookup = useLookupName(
-      value ? value.network : null,
-      walletAddress ? walletAddress.toLowerCase() : null,
-    )
+    const addressLookup = useLookupName(value?.network, walletAddress?.toLowerCase())
 
     const addressPlaceholder = walletAddress ? truncateAddress(walletAddress, 4, 4) : ''
     const accountName = addressLookup ? addressLookup : addressPlaceholder

--- a/app/src/components/ChainSelect.tsx
+++ b/app/src/components/ChainSelect.tsx
@@ -1,17 +1,19 @@
 'use client'
-import { useOutsideClick } from '@/hooks/useOutsideClick'
+import { forwardRef, useRef, useState } from 'react'
+import Image from 'next/image'
+import { twMerge } from 'tailwind-merge'
+
 import { Chain } from '@/models/chain'
 import { ManualRecipient, SelectProps } from '@/models/select'
-import Image from 'next/image'
-import { forwardRef, useEffect, useRef, useState } from 'react'
-import { twMerge } from 'tailwind-merge'
+import useLookupName from '@/hooks/useLookupName'
+import { useOutsideClick } from '@/hooks/useOutsideClick'
+import { truncateAddress } from '@/utils/address'
+
 import Dropdown from './Dropdown'
 import ChainIcon from './svg/ChainIcon'
 import ChevronDown from './svg/ChevronDown'
 import { Tooltip } from './Tooltip'
 import VerticalDivider from './VerticalDivider'
-import { truncateAddress } from '@/utils/address'
-import { lookupName } from '@/utils/transfer'
 
 interface ChainSelectProps extends SelectProps<Chain> {
   walletAddress?: string
@@ -39,12 +41,16 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
     ref,
   ) => {
     const [isOpen, setIsOpen] = useState(false)
-    const [accountName, setAccountName] = useState('')
-
     const triggerRef = useRef<HTMLDivElement>(null)
     const dropdownRef = useRef<HTMLDivElement>(null)
-
     useOutsideClick(triggerRef, dropdownRef, () => setIsOpen(false))
+    const addressLookup = useLookupName(
+      value ? value.network : null,
+      walletAddress ? walletAddress.toLowerCase() : null,
+    )
+
+    const addressPlaceholder = walletAddress ? truncateAddress(walletAddress, 4, 4) : ''
+    const accountName = addressLookup ? addressLookup : addressPlaceholder
 
     const handleSelectionChange = (selectedChain: Chain) => {
       onChange(selectedChain)
@@ -63,21 +69,6 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
     const shouldShowChainName =
       (!walletAddress && (!manualRecipient?.enabled || !manualRecipient?.address)) ||
       (manualRecipient?.enabled && !manualRecipient.address)
-
-    useEffect(() => {
-      const fetchNames = async () => {
-        let placeholder = walletAddress ? truncateAddress(walletAddress, 4, 4) : ''
-        if (!value) return
-
-        setAccountName(
-          !!walletAddress
-            ? (await lookupName(value?.network, walletAddress)) ?? placeholder
-            : placeholder,
-        )
-      }
-
-      fetchNames()
-    })
 
     return (
       <div ref={ref} className={twMerge('relative w-full', className)}>

--- a/app/src/hooks/useLookupName.tsx
+++ b/app/src/hooks/useLookupName.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { Network } from '@/models/chain'
 import { lookupName } from '@/utils/transfer'
 
-const useLookupName = (network: Network | null, address: string | null) => {
+const useLookupName = (network?: Network, address?: string) => {
   const [accountName, setAccountName] = useState<string | null>(null)
 
   const fetchName = useCallback(async () => {
@@ -18,7 +18,6 @@ const useLookupName = (network: Network | null, address: string | null) => {
     } catch (e) {
       // Do not throw an error here
       console.error('Address lookup error:', e)
-      setAccountName(null)
     }
   }, [network, address])
 

--- a/app/src/hooks/useLookupName.tsx
+++ b/app/src/hooks/useLookupName.tsx
@@ -1,17 +1,24 @@
-import { Network } from '@/models/chain'
-import { lookupName } from '@/utils/transfer'
 import { useCallback, useEffect, useState } from 'react'
 
-const useLookupName = (network: Network, address: string) => {
-  const [accountName, setAccountName] = useState<string | null>()
+import { Network } from '@/models/chain'
+import { lookupName } from '@/utils/transfer'
+
+const useLookupName = (network: Network | null, address: string | null) => {
+  const [accountName, setAccountName] = useState<string | null>(null)
 
   const fetchName = useCallback(async () => {
+    if (!network || !address) {
+      setAccountName(null)
+      return
+    }
+
     try {
       const name = await lookupName(network, address)
       setAccountName(name)
     } catch (e) {
       // Do not throw an error here
-      console.error(e)
+      console.error('Address lookup error:', e)
+      setAccountName(null)
     }
   }, [network, address])
 


### PR DESCRIPTION
This PR contains 
- an improvement of the **useLookupName** to support initialization with **null** values. 
- a small refactoring of fetch ens names from the **Chain Select** fetching component to rely on the useLookupName hook. It should **handle address & network changes to prevent rendering issues. 🤞**

**However:** I have not been able to reproduce the known issue from the mainnet. This PR needs testing on Mainnet as I do not own any ENS for my addresses on Eth mainnet. Tests have been made on Sepolia using a different provider. 
In case the issue is still here, we should consider updating the provider.
