### PR TITLE
ad-hoc: Show current balance for selected token

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -110,3 +110,17 @@ input[type='number']::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+input {
+  font-size: 18px;
+  font-weight: 400;
+}
+
+input::placeholder {
+  color: var(--turtle-level4);
+  opacity: 1; /* Firefox */
+}
+
+input::-ms-input-placeholder { /* Edge 12 -18 */
+  color: var(--turtle-level4);
+}

--- a/app/src/components/TokenAmountSelect.tsx
+++ b/app/src/components/TokenAmountSelect.tsx
@@ -23,6 +23,7 @@ const TokenAmountSelect = forwardRef<HTMLDivElement, TokenAmountSelectProps>(
       floatingLabel,
       placeholder = 'Token',
       placeholderIcon = <TokenIcon />,
+      secondPlaceholder,
       trailing,
       disabled,
       error,
@@ -90,7 +91,7 @@ const TokenAmountSelect = forwardRef<HTMLDivElement, TokenAmountSelectProps>(
               <input
                 type="number"
                 className="h-[70%] bg-transparent focus:border-0 focus:outline-none"
-                placeholder="Amount"
+                placeholder={secondPlaceholder ?? "Amount"}
                 value={value?.amount ?? ''}
                 onChange={handleAmountChange}
                 onClick={e => e.stopPropagation()}

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -41,9 +41,7 @@ const Transfer: FC = () => {
     balanceData,
   } = useTransferForm()
 
-  const amountPlaceholder = !isBalanceAvailable ? "Amount" : balanceData?.value == BigInt(0) ? "No balance :(" : `${Number(balanceData?.formatted).toFixed(3).toString() + ' ' + tokenAmount?.token?.symbol} `
-
-  console.log("Transfer - balance is ", balanceData)
+  const amountPlaceholder = tokenAmount?.token == null ? "Amount" : balanceData?.value == BigInt(0) ? "No balance :(" : `${Number(balanceData?.formatted).toFixed(3).toString() + ' ' + tokenAmount?.token?.symbol}`
 
   return (
     <form

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -38,7 +38,12 @@ const Transfer: FC = () => {
     tokenAmountError,
     manualRecipientError,
     isBalanceAvailable,
+    balanceData,
   } = useTransferForm()
+
+  const amountPlaceholder = !isBalanceAvailable ? "Amount" : balanceData?.value == BigInt(0) ? "No balance :(" : `${Number(balanceData?.formatted).toFixed(3).toString() + ' ' + tokenAmount?.token?.symbol} `
+
+  console.log("Transfer - balance is ", balanceData)
 
   return (
     <form
@@ -75,6 +80,7 @@ const Transfer: FC = () => {
               options={REGISTRY[environment].tokens.map(token => ({ token, amount: null }))}
               floatingLabel="Amount"
               disabled={transferStatus !== 'Idle'}
+              secondPlaceholder={amountPlaceholder}
               error={errors.tokenAmount?.amount?.message || tokenAmountError}
               trailing={
                 <Button

--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -255,6 +255,7 @@ const useTransferForm = () => {
     tokenAmountError,
     manualRecipientError,
     isBalanceAvailable: balanceData?.value && balanceData.value > 0,
+    balanceData,
   }
 }
 

--- a/app/src/models/select.ts
+++ b/app/src/models/select.ts
@@ -9,6 +9,7 @@ export interface SelectProps<T> {
   floatingLabel?: string
   placeholder?: string
   placeholderIcon?: ReactNode
+  secondPlaceholder?: string
   trailing?: ReactNode
   disabled?: boolean
   error?: string


### PR DESCRIPTION
Show current balance for selected token And tweak input styling more according to the figma specs.

NOTE: This is a temporary design solution until Brandon designs it.

### How it looks

A. No selected token
<img width="450" alt="Screenshot 2024-07-18 at 12 18 23" src="https://github.com/user-attachments/assets/92a30d10-f8e5-4b2e-9b27-cb76360a3d03">

B. Selected token with balance
<img width="451" alt="Screenshot 2024-07-18 at 12 13 09" src="https://github.com/user-attachments/assets/9667e5c1-43cf-45c4-a074-e8adde972f02">

C. Selected token without balance
<img width="439" alt="Screenshot 2024-07-18 at 12 18 12" src="https://github.com/user-attachments/assets/c1ea9e94-7930-4d3e-ba42-e6d45dcdb97e">
