### PR TITLE
Feat/progress bar

### DIFF
--- a/app/src/components/FeesPreview.tsx
+++ b/app/src/components/FeesPreview.tsx
@@ -1,5 +1,5 @@
 import { Fees } from '@/models/transfer'
-import { feeToHuman } from '@/utils/transfer'
+import { feeToHuman, formatAmount, toHuman } from '@/utils/transfer'
 import { AnimatePresence, motion } from 'framer-motion'
 import { FC } from 'react'
 import { spinnerSize } from './Button'
@@ -34,10 +34,10 @@ const FeesPreview: FC<FeesPreviewProps> = ({ loading, fees, hidden }) => {
           <div className="mt-4 flex items-center justify-between border-y border-turtle-level2 py-3">
             <div>
               <div className="text-turtle-foreground">
-                {feeToHuman(fees)} {fees.token.symbol}
+                {formatAmount(toHuman(fees.amount, fees.token))} {fees.token.symbol}
               </div>
               {fees.inDollars > 0 && (
-                <div className="text-turtle-level3">${fees.inDollars.toFixed(3)}</div>
+                <div className="text-turtle-level3">${formatAmount(fees.inDollars)}</div>
               )}
             </div>
             <div className="flex items-center">

--- a/app/src/components/OngoingTransfer.tsx
+++ b/app/src/components/OngoingTransfer.tsx
@@ -12,6 +12,7 @@ import { ArrowRight } from './svg/ArrowRight'
 import LoadingIcon from './svg/LoadingIcon'
 
 import { colors } from '../../tailwind.config'
+import ProgressBar from './ProgressBar'
 
 const OngoingTransfer: FC<{
   transfer: StoredTransfer
@@ -27,17 +28,8 @@ const OngoingTransfer: FC<{
         </p>
       </div>
       {/* Progress bar */}
-      <div
-        className={cn(
-          'mb-4 h-2 overflow-hidden rounded-full bg-turtle-secondary-light',
-          progression <= 0 && 'animate-pulse',
-        )}
-      >
-        <div
-          className="h-full rounded-full border border-turtle-secondary-dark bg-turtle-secondary transition-all duration-700 ease-in-out"
-          style={{ transform: `translateX(-${100 - (progression || 0)}%)` }}
-        />
-      </div>
+      <ProgressBar progression={progression} outlinedProgressBar={false} />
+
       <div className="mb-2 flex items-center">
         <LoadingIcon
           className="mr-2 animate-spin"

--- a/app/src/components/OngoingTransfer.tsx
+++ b/app/src/components/OngoingTransfer.tsx
@@ -15,7 +15,8 @@ import { colors } from '../../tailwind.config'
 const OngoingTransfer: FC<{
   transfer: StoredTransfer
   update: string | null
-}> = ({ transfer, update }) => {
+  progression: number
+}> = ({ transfer, update, progression }) => {
   return (
     <div className="mb-2 rounded-[16px] border border-turtle-level3 p-3 hover:cursor-pointer">
       <div className="mb-2 flex items-center justify-between">
@@ -28,7 +29,7 @@ const OngoingTransfer: FC<{
       <div className="mb-4 h-2 rounded-full bg-turtle-secondary-light">
         <div
           className="h-2 rounded-full border border-turtle-secondary-dark bg-turtle-secondary"
-          style={{ width: '60%' }}
+          style={{ width: `${progression}%` }}
         />
       </div>
       <div className="mb-2 flex items-center">

--- a/app/src/components/OngoingTransfer.tsx
+++ b/app/src/components/OngoingTransfer.tsx
@@ -29,16 +29,14 @@ const OngoingTransfer: FC<{
       {/* Progress bar */}
       <div
         className={cn(
-          'mb-4 h-2 rounded-full bg-turtle-secondary-light',
+          'mb-4 h-2 overflow-hidden rounded-full bg-turtle-secondary-light',
           progression <= 0 && 'animate-pulse',
         )}
       >
-        {progression > 0 && (
-          <div
-            className="h-full rounded-full border border-turtle-secondary-dark bg-turtle-secondary transition-all duration-700 ease-in-out"
-            style={{ width: `${progression}%` }}
-          />
-        )}
+        <div
+          className="h-full rounded-full border border-turtle-secondary-dark bg-turtle-secondary transition-all duration-700 ease-in-out"
+          style={{ transform: `translateX(-${100 - (progression || 0)}%)` }}
+        />
       </div>
       <div className="mb-2 flex items-center">
         <LoadingIcon

--- a/app/src/components/OngoingTransfer.tsx
+++ b/app/src/components/OngoingTransfer.tsx
@@ -6,6 +6,7 @@ import { StoredTransfer } from '@/models/transfer'
 import { truncateAddress } from '@/utils/address'
 import { formatOngoingTransferDate } from '@/utils/datetime'
 import { formatAmount, toHuman } from '@/utils/transfer'
+import { cn } from '@/utils/cn'
 
 import { ArrowRight } from './svg/ArrowRight'
 import LoadingIcon from './svg/LoadingIcon'
@@ -26,11 +27,18 @@ const OngoingTransfer: FC<{
         </p>
       </div>
       {/* Progress bar */}
-      <div className="mb-4 h-2 rounded-full bg-turtle-secondary-light">
-        <div
-          className="h-2 rounded-full border border-turtle-secondary-dark bg-turtle-secondary"
-          style={{ width: `${progression}%` }}
-        />
+      <div
+        className={cn(
+          'mb-4 h-2 rounded-full bg-turtle-secondary-light',
+          progression <= 0 && 'animate-pulse',
+        )}
+      >
+        {progression > 0 && (
+          <div
+            className="h-full rounded-full border border-turtle-secondary-dark bg-turtle-secondary transition-all duration-700 ease-in-out"
+            style={{ width: `${progression}%` }}
+          />
+        )}
       </div>
       <div className="mb-2 flex items-center">
         <LoadingIcon

--- a/app/src/components/OngoingTransferDialog.tsx
+++ b/app/src/components/OngoingTransferDialog.tsx
@@ -31,6 +31,7 @@ import {
 import { Separator } from './ui/separator'
 
 import { colors } from '../../tailwind.config'
+import ProgressBar from './ProgressBar'
 
 export const OngoingTransferDialog = ({
   transfer,
@@ -171,14 +172,8 @@ export const OngoingTransferDialog = ({
                 {formatOngoingTransferDate(transfer.date)}
               </p>
             </div>
-            <div className="mb-4 h-2 rounded-full border border-turtle-secondary bg-white">
-              {progression > 0 && (
-                <div
-                  className="-ml-[1px] -mt-[1px] h-2 rounded-full border border-turtle-secondary-dark bg-turtle-secondary"
-                  style={{ width: `${progression}%` }}
-                />
-              )}
-            </div>
+
+            <ProgressBar progression={progression} outlinedProgressBar={true} />
           </div>
 
           {/* sender */}

--- a/app/src/components/OngoingTransfers.tsx
+++ b/app/src/components/OngoingTransfers.tsx
@@ -10,28 +10,23 @@ import OngoingTransferDialog from './OngoingTransferDialog'
 import { SnowbridgeStatus } from '@/models/snowbridge'
 import { getSnowBridgeStatus } from '@/context/snowbridge'
 
-const initBridgeStatus = {
-  ethBridgeStatus: 15,
-  polkadotBridgeStatus: 15,
-}
-
 const OngoingTransfers = ({
   isNewTransaction,
   setIsNewTransaction,
   isCompletedTransactions,
 }: DisplaysTransfers) => {
   const ongoingTransfers = useStore(useOngoingTransfersStore, state => state.transfers)
-  const [bridgeStatus, setBridgeStatus] = useState<SnowbridgeStatus>(initBridgeStatus)
+  const [bridgeStatus, setBridgeStatus] = useState<SnowbridgeStatus | null>(null)
 
-  const DEFAULT_AVERAGE_BRIDGE_EXECUTION = 30
+  const DEFAULT_AVERAGE_BRIDGE_EXECUTION = 30 // minutes
 
   const getBridgeStatus = async () => {
     try {
       setBridgeStatus(await getSnowBridgeStatus())
     } catch (error) {
       const status = {
-        ethBridgeStatus: DEFAULT_AVERAGE_BRIDGE_EXECUTION * 60,
-        polkadotBridgeStatus: DEFAULT_AVERAGE_BRIDGE_EXECUTION * 60,
+        ethBridgeStatus: DEFAULT_AVERAGE_BRIDGE_EXECUTION * 60, // converted to seconds
+        polkadotBridgeStatus: DEFAULT_AVERAGE_BRIDGE_EXECUTION * 60, // converted to seconds
       }
       setBridgeStatus(status)
       console.log('Set bridge status error: ', error)
@@ -40,7 +35,6 @@ const OngoingTransfers = ({
 
   useEffect(() => {
     let shouldUpdate = true
-
     shouldUpdate && getBridgeStatus()
 
     return () => {

--- a/app/src/components/ProgressBar.tsx
+++ b/app/src/components/ProgressBar.tsx
@@ -1,0 +1,38 @@
+import { FC } from 'react'
+import { cn } from '@/utils/cn'
+
+interface ProgressBarProps {
+  progression: number
+  outlinedProgressBar: boolean
+}
+
+const ProgressBar: FC<ProgressBarProps> = ({ progression, outlinedProgressBar }) => {
+  return (
+    <>
+      {!outlinedProgressBar ? (
+        <div
+          className={cn(
+            'mb-4 h-2 overflow-hidden rounded-full bg-turtle-secondary-light',
+            progression <= 0 && 'animate-pulse',
+          )}
+        >
+          <div
+            className="h-full rounded-full border border-turtle-secondary-dark bg-turtle-secondary transition-all duration-700 ease-in-out"
+            style={{ transform: `translateX(-${100 - (progression || 0)}%)` }}
+          />
+        </div>
+      ) : (
+        <div className="mb-4 h-2 rounded-full border border-turtle-secondary bg-white">
+          {progression > 0 && (
+            <div
+              className="-ml-[1px] -mt-[1px] h-2 rounded-full border border-turtle-secondary-dark bg-turtle-secondary"
+              style={{ width: `${progression}%` }}
+            />
+          )}
+        </div>
+      )}
+    </>
+  )
+}
+
+export default ProgressBar

--- a/app/src/context/snowbridge.tsx
+++ b/app/src/context/snowbridge.tsx
@@ -82,6 +82,16 @@ export async function getSnowBridgeStatus(): Promise<SnowbridgeStatus> {
   }
 }
 
+/**
+ * Calculates the progression value of snowbridge transfer based on its status,
+ * the transfer date, and the transfer direction.
+ *
+ * @param bridgeStatus - Snowbridge's last status. This object contains the bridge status
+ * in minutes for both Polkadot and Ethereum directions. If null, the function returns 0.
+ * @param transferDate - The date and time when the transfer was initiated.
+ * @param transferDirection - The direction of the transfer, either ToPolkadot or ToEthereum direction.
+ * @returns The progression value of the bridge transfer process, ranging between 5% and 90%.
+ */
 export const bridgeProgressionValue = (
   bridgeStatus: SnowbridgeStatus | null,
   transferDate: Date,

--- a/app/src/models/snowbridge.ts
+++ b/app/src/models/snowbridge.ts
@@ -1,0 +1,4 @@
+export type SnowbridgeStatus = {
+  ethBridgeStatus: number
+  polkadotBridgeStatus: number
+}


### PR DESCRIPTION
This PR handles the ongoing transfer progress bar. 
It fetches Snowbridge's last status (in minutes) and format available data to compute a % of the actual progression. 
Min value displayed 5 % max value 90% for a better UI/UX. 

It includes some animation and css fix. 

[To be noted besides it I also try the same implementation using SWR to get a better performance.](https://swr.vercel.app/fr-FR) It works well but I still need to fine-tune my approach. 