### PR TITLE
fix: persist progressbar data

### DIFF
--- a/app/src/hooks/useSnowbridgeTransferEstimate.tsx
+++ b/app/src/hooks/useSnowbridgeTransferEstimate.tsx
@@ -11,7 +11,7 @@ const useSnowbridgeTransferEstimate = (
   transferStatus?: SnowbridgeStatus,
 ) => {
   const [progress, setProgress] = useState<number>(
-    // Caluculate progress from cache if transferStatus is available
+    // Calculate progress from cache if transferStatus is available
     estimateBridgeProgress(transfer.date, direction, transferStatus),
   )
   const progressIntervalRef = useRef<NodeJS.Timeout | null>(null)

--- a/app/src/hooks/useSnowbridgeTransferEstimate.tsx
+++ b/app/src/hooks/useSnowbridgeTransferEstimate.tsx
@@ -10,7 +10,10 @@ const useSnowbridgeTransferEstimate = (
   direction: Direction,
   transferStatus?: SnowbridgeStatus,
 ) => {
-  const [progress, setProgress] = useState<number>(0)
+  const [progress, setProgress] = useState<number>(
+    // Caluculate progress from cache if transferStatus is available
+    estimateBridgeProgress(transfer.date, direction, transferStatus),
+  )
   const progressIntervalRef = useRef<NodeJS.Timeout | null>(null)
 
   const updateProgress = () => {
@@ -23,7 +26,13 @@ const useSnowbridgeTransferEstimate = (
   }
 
   useEffect(() => {
+    // Initiate the progress bar without waiting the 5 secs timeout.
+    if (progress === 0)
+      setProgress(estimateBridgeProgress(transfer.date, direction, transferStatus))
+    // Set a time-interval to update the progress bar every 5 seconds
     progressIntervalRef.current = setInterval(updateProgress, 5000)
+
+    // Clean-up function to remove the time-interval when component unmount
     return () => {
       if (progressIntervalRef.current) {
         clearInterval(progressIntervalRef.current)


### PR DESCRIPTION
It persists the progressBar data using the available cache and removes the lag between the transfer card and the dialog.
