### PR TITLE
fix: invalid date on first load

### DIFF
--- a/app/src/components/completed/TransactionDialog.tsx
+++ b/app/src/components/completed/TransactionDialog.tsx
@@ -127,7 +127,7 @@ export const TransactionDialog = ({ tx }: { tx: CompletedTransfer }) => {
                 : ' text-turtle-error-dark',
             )}
           >
-            <div>{formatCompletedTransferDate(tx.date.toString().split('T')[0])}</div>
+            <div>{formatCompletedTransferDate(tx.date)}</div>
             <div>{formatHours(tx.date)}</div>
           </div>
         </DialogHeader>

--- a/app/src/components/completed/TransactionHistory.tsx
+++ b/app/src/components/completed/TransactionHistory.tsx
@@ -5,7 +5,13 @@ import { TransactionDialog } from './TransactionDialog'
 
 const TransactionHistory = ({ transactions }: { transactions: CompletedTransfer[] }) => {
   const transactionsByDate = transactions.reduce<TransfersByDate>((acc, transaction) => {
-    const date = transaction.date.toString().split('T')[0]
+    let date: string
+    if (typeof transaction.date === 'string') {
+      date = new Date(transaction.date).toISOString().split('T')[0]
+    } else {
+      date = transaction.date.toISOString().split('T')[0]
+    }
+
     if (!acc[date]) {
       acc[date] = []
     }

--- a/app/src/components/completed/TransactionHistory.tsx
+++ b/app/src/components/completed/TransactionHistory.tsx
@@ -8,8 +8,10 @@ const TransactionHistory = ({ transactions }: { transactions: CompletedTransfer[
     let date: string
     if (typeof transaction.date === 'string') {
       date = new Date(transaction.date).toISOString().split('T')[0]
-    } else {
+    } else if (transaction.date instanceof Date) {
       date = transaction.date.toISOString().split('T')[0]
+    } else {
+      date = 'Unknown date'
     }
 
     if (!acc[date]) {


### PR DESCRIPTION
Currently, the issue is the following: 

On the first load of an ongoing or completed transfer from localstorage, they are not serialized while after a refresh of the app, the localstorage serialized dates from Date type to string. 

This fix should support the formatting of both formats as it now converts the date into an ISO format. 