### PR TITLE
fix mt on completed tx

### DIFF
--- a/app/src/components/completed/TransactionHistory.tsx
+++ b/app/src/components/completed/TransactionHistory.tsx
@@ -2,6 +2,7 @@ import { CompletedTransfer, TransfersByDate } from '@/models/transfer'
 import { formatCompletedTransferDate } from '@/utils/datetime'
 
 import { TransactionDialog } from './TransactionDialog'
+import { cn } from '@/utils/cn'
 
 const TransactionHistory = ({ transactions }: { transactions: CompletedTransfer[] }) => {
   const transactionsByDate = transactions.reduce<TransfersByDate>((acc, transaction) => {
@@ -32,7 +33,7 @@ const TransactionHistory = ({ transactions }: { transactions: CompletedTransfer[
       {mappedTransactionsByDate.map(({ date, transactions }, idx) => (
         <div key={idx + date + transactions.length}>
           <div className="w-full space-y-3">
-            <p className="tx-group-date mb-[-1] mt-5 text-sm">
+            <p className={cn('tx-group-date mb-[-1] text-sm', idx !== 0 && 'mt-5')}>
               {formatCompletedTransferDate(date)}
             </p>
             {transactions.map((tx, idx) => (


### PR DESCRIPTION
removes the margin-top from the first item of the completed transfers: 

Before:
<img width="604" alt="Capture d’écran 2024-08-27 à 11 43 05" src="https://github.com/user-attachments/assets/5d7570ee-6a21-4fff-a359-728e83b5d3ce">

After: 
<img width="598" alt="Capture d’écran 2024-08-27 à 11 42 58" src="https://github.com/user-attachments/assets/f7925367-ede7-4827-bdbb-a35d5d42b038">
