### PR TITLE
fix: Preserve Transfer form state on menu tab switch

### DIFF
--- a/app/src/components/HomeComponentSelect.tsx
+++ b/app/src/components/HomeComponentSelect.tsx
@@ -31,7 +31,7 @@ export const HomeComponentSelect = () => {
       <div
         className={cn(
           'z-15 relative max-w-[90vw]',
-          newTransferInit !== TransferTab.New ? 'hidden' : '',
+          newTransferInit !== TransferTab.New && 'hidden',
         )}
       >
         <Transfer />

--- a/app/src/components/HomeComponentSelect.tsx
+++ b/app/src/components/HomeComponentSelect.tsx
@@ -9,6 +9,7 @@ import { TransferTabOptions, TransferTab } from '@/models/transfer'
 
 import OngoingTransfers from './OngoingTransfers'
 import TransactionLoaderSkeleton from './completed/TransactionLoaderSkeleton'
+import { cn } from '@/utils/cn'
 
 const TransferHistory = dynamic(() => import('@/components/completed/TransactionHistory'), {
   loading: () => <TransactionLoaderSkeleton />,
@@ -26,18 +27,23 @@ export const HomeComponentSelect = () => {
         setNewTransferInit={setNewTransferInit}
         hasCompletedTransfers={hasCompletedTransfers}
       />
-      {newTransferInit === TransferTab.New ? (
-        <div className="z-15 relative max-w-[90vw]">
-          <Transfer />
-          <OngoingTransfers
-            newTransferInit={newTransferInit}
-            setNewTransferInit={setNewTransferInit}
-            hasCompletedTransfers={hasCompletedTransfers}
-          />
-        </div>
-      ) : (
-        hasCompletedTransfers &&
-        completedTransfers && <TransferHistory transactions={completedTransfers} />
+
+      <div
+        className={cn(
+          'z-15 relative max-w-[90vw]',
+          newTransferInit !== TransferTab.New ? 'hidden' : '',
+        )}
+      >
+        <Transfer />
+        <OngoingTransfers
+          newTransferInit={newTransferInit}
+          setNewTransferInit={setNewTransferInit}
+          hasCompletedTransfers={hasCompletedTransfers}
+        />
+      </div>
+
+      {hasCompletedTransfers && completedTransfers && (
+        <TransferHistory transactions={completedTransfers!} />
       )}
     </>
   )

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -329,7 +329,7 @@ const Transfer: FC = () => {
           >
             <ActionBanner
               disabled={isSwappingEthForWEth}
-              header={'Swap ETH to wETH'}
+              header={'Swap ETH for wETH'}
               text={'Your wETH balance is insufficient but you got enough ETH.'}
               image={<Image src={'/wallet.svg'} alt={'Wallet'} width={64} height={64} />}
               btn={{


### PR DESCRIPTION
Fixes https://linear.app/velocitylabs/issue/VEL-60/preserve-transfer-form-state-when-switching-to-completed-transfers

### Changes 
Basically, instead of rendering or removing the form and ongoing txs components based on the selected tab, we show or hide it, respectively.