### PR TITLE
improvement: transfer tracking cleaning

### DIFF
--- a/app/src/app/api/history/route.ts
+++ b/app/src/app/api/history/route.ts
@@ -11,7 +11,8 @@ import { OngoingTransferWithDirection, OngoingTransfers } from '@/models/transfe
 import { Direction } from '@/services/transfer'
 import { Environment } from '@/store/environmentStore'
 import { shouldUseTestnet } from '@/utils/env'
-import { getErrorMessage, getTransferHistory } from '@/utils/snowbridge'
+import { getTransferHistory } from '@/utils/snowbridge'
+import { getErrorMessage } from '@/utils/transferTracking'
 
 const CACHE_REVALIDATE_IN_SECONDS = 30
 

--- a/app/src/app/api/history/route.ts
+++ b/app/src/app/api/history/route.ts
@@ -11,8 +11,7 @@ import { OngoingTransferWithDirection, OngoingTransfers } from '@/models/transfe
 import { Direction } from '@/services/transfer'
 import { Environment } from '@/store/environmentStore'
 import { shouldUseTestnet } from '@/utils/env'
-import { getTransferHistory } from '@/utils/snowbridge'
-import { getErrorMessage } from '@/utils/transferTracking'
+import { getErrorMessage, trackTransfers } from '@/utils/transferTracking'
 
 const CACHE_REVALIDATE_IN_SECONDS = 30
 
@@ -48,7 +47,7 @@ const getCachedTransferHistory = unstable_cache(
         }
       })
 
-      return getTransferHistory(env, transfers)
+      return trackTransfers(env, transfers)
     } catch (err) {
       reportError(err)
       return Promise.resolve([])

--- a/app/src/components/OngoingTransfers.tsx
+++ b/app/src/components/OngoingTransfers.tsx
@@ -6,7 +6,7 @@ import useSnowbridgeContext from '@/hooks/useSnowbridgeContext'
 import { DisplaysTransfers, TransferTab } from '@/models/transfer'
 import { useOngoingTransfersStore } from '@/store/ongoingTransfersStore'
 import OngoingTransferDialog from './OngoingTransferDialog'
-import useSnowbridgeTransferTracker from '@/hooks/useSnowbridgeTransferTracker'
+import useOngoingTransfersTracker from '@/hooks/useOngoingTransfersTracker'
 import { ArrowRight } from './svg/ArrowRight'
 import { colors } from '../../tailwind.config'
 
@@ -34,7 +34,7 @@ const OngoingTransfers = ({
     isSnowbridgeContextLoading: transferContextLoading,
     snowbridgeContextError: transferContextError,
   } = useSnowbridgeContext()
-  const { statusMessages } = useSnowbridgeTransferTracker()
+  const { statusMessages } = useOngoingTransfersTracker()
 
   const { data: estimatedTransferDuration, error: estimatedTransferDurationError } = useQuery({
     queryKey: ['transferStatus', transferContextLoading, ongoingTransfers.length],

--- a/app/src/utils/snowbridge.ts
+++ b/app/src/utils/snowbridge.ts
@@ -1,28 +1,17 @@
 import { AlchemyProvider } from 'ethers'
 import { environment, subscan, history } from '@snowbridge/api'
-import {
-  ToEthereumTransferResult,
-  ToPolkadotTransferResult,
-  TransferStatus,
-} from '@snowbridge/api/dist/history'
-import { BeefyClient__factory, IGateway__factory } from '@snowbridge/contract-types'
-import { OngoingTransfers } from '@/models/transfer'
-import { SubscanXCMTransferResult } from '@/models/subscan'
-
-import { trackXcmTransfer } from './subscan'
+import { IGateway__factory } from '@snowbridge/contract-types'
 
 export const SKIP_LIGHT_CLIENT_UPDATES = true
 export const HISTORY_IN_SECONDS = 60 * 60 * 24 * 2 // 2 days
 export const ETHEREUM_BLOCK_TIME_SECONDS = 12
 export const ACCEPTABLE_BRIDGE_LATENCY = 28800 // 8 hours
 
-export async function getTransferHistory(
+export async function trackFromEthTx(
   env: environment.SnowbridgeEnvironment,
-  ongoingTransfers: OngoingTransfers,
   skipLightClientUpdates = SKIP_LIGHT_CLIENT_UPDATES,
   historyInSeconds = HISTORY_IN_SECONDS,
-) {
-  console.log('Fetching transfer history.')
+): Promise<history.ToPolkadotTransferResult[]> {
   if (!env.config.SUBSCAN_API) {
     console.warn(`No subscan api urls configured for ${env.name}`)
     return []
@@ -41,13 +30,8 @@ export async function getTransferHistory(
 
   const assetHubScan = subscan.createApi(env.config.SUBSCAN_API.ASSET_HUB_URL, subscanKey)
   const bridgeHubScan = subscan.createApi(env.config.SUBSCAN_API.BRIDGE_HUB_URL, subscanKey)
-  const relaychainScan = subscan.createApi(env.config.SUBSCAN_API.RELAY_CHAIN_URL, subscanKey)
-
   const bridgeHubParaId = env.config.BRIDGE_HUB_PARAID
-  const assetHubParaId = env.config.ASSET_HUB_PARAID
   const beacon_url = env.config.BEACON_HTTP_API
-
-  const beefyClient = BeefyClient__factory.connect(env.config.BEEFY_CONTRACT, ethereumProvider)
   const gateway = IGateway__factory.connect(env.config.GATEWAY_CONTRACT, ethereumProvider)
   const ethereumSearchPeriodBlocks = historyInSeconds / ETHEREUM_BLOCK_TIME_SECONDS
 
@@ -86,161 +70,15 @@ export async function getTransferHistory(
     },
   }
 
-  const transfers: (
-    | ToEthereumTransferResult
-    | ToPolkadotTransferResult
-    | SubscanXCMTransferResult
-  )[] = []
-
-  if (ongoingTransfers.toEthereum.fromAssetHub.length) {
-    // Switch code below to test the other tracking method
-
-    const toEthereum = await history.toEthereumHistory(
-      assetHubScan,
-      bridgeHubScan,
-      relaychainScan,
-      searchRange,
-      skipLightClientUpdates,
-      env.ethChainId,
-      assetHubParaId,
-      beefyClient,
-      gateway,
-    )
-    console.log('From AH To Ethereum transfers:', toEthereum.length)
-    transfers.push(...toEthereum)
-
-    // const toEthereum = await trackXcmTransfer(
-    //   relaychainScan,
-    //   ongoingTransfers.toEthereum.fromAssetHub,
-    // )
-    // console.log('From AH To Ethereum transfer:', toEthereum.length)
-    // transfers.push(...toEthereum)
-  }
-
-  if (ongoingTransfers.toEthereum.fromParachain.length) {
-    const fromParachainTransfer = await trackXcmTransfer(
-      relaychainScan,
-      ongoingTransfers.toEthereum.fromParachain,
-    )
-    console.log('From Parachain/AH To Ethereum transfer:', fromParachainTransfer)
-    transfers.push(...fromParachainTransfer)
-  }
-
-  if (ongoingTransfers.toPolkadot.length) {
-    const toPolkadot = await history.toPolkadotHistory(
-      assetHubScan,
-      bridgeHubScan,
-      searchRange,
-      skipLightClientUpdates,
-      bridgeHubParaId,
-      gateway,
-      ethereumProvider,
-      beacon_url,
-    )
-    console.log('From ETH To Polkadot transfers:', toPolkadot.length)
-    transfers.push(...toPolkadot)
-  }
-
-  return transfers.sort((a, b) => getTransferTimestamp(b) - getTransferTimestamp(a))
-}
-
-export interface AccountInfo {
-  name: string
-  type: 'ethereum' | 'substrate'
-  account: string
-  balance: string
-}
-
-export function getTransferStatus(
-  transferResult: ToEthereumTransferResult | ToPolkadotTransferResult | SubscanXCMTransferResult,
-) {
-  /**  Checks if the transfer result has been tracked by Snowbridge for a transfer to Ethereum.*/
-  const isSnowbridgeTrackingToEth =
-    'info' in transferResult && transferResult.info.destinationParachain == undefined
-  /**  Checks if the transfer result has been tracked by Subscan for an XCM transfer to Ethereum.*/
-  const isSubscanXCMTrackingToEth =
-    'destEventIndex' in transferResult && !('info' in transferResult)
-
-  if (isSnowbridgeTrackingToEth)
-    return getTransferStatusToEthereum(transferResult as ToEthereumTransferResult)
-  else if (isSubscanXCMTrackingToEth) {
-    return getTransferStatusToEthereum(transferResult as SubscanXCMTransferResult)
-  } else {
-    /** Retrieves the status of a transfer to Polkadot from a Snowbridge result */
-    return getTransferStatusToPolkadot(transferResult as ToPolkadotTransferResult)
-  }
-}
-
-export function getTransferStatusToEthereum(
-  transferResult: ToEthereumTransferResult | SubscanXCMTransferResult,
-) {
-  /** Bridge Hub Channel Message Delivered */
-  const isBHChannelMsgDeliveredInSnowbridgeRes =
-    'bridgeHubChannelDelivered' in transferResult &&
-    transferResult.bridgeHubChannelDelivered?.success
-  /** Destination Event Index available */
-  const isDestEventIdxInSubscanXCMRes =
-    'destEventIndex' in transferResult && transferResult.destEventIndex.length > 0
-  /** Transfer just submitted from AH */
-  const isTransferSubmittedInSnowbridgeRes = 'submitted' in transferResult
-
-  switch (transferResult.status) {
-    case TransferStatus.Pending:
-      if (isBHChannelMsgDeliveredInSnowbridgeRes || isDestEventIdxInSubscanXCMRes)
-        return 'Arriving at Ethereum'
-      if (
-        isTransferSubmittedInSnowbridgeRes ||
-        !transferResult.destEventIndex ||
-        !isDestEventIdxInSubscanXCMRes
-      )
-        return 'Arriving at Bridge Hub'
-      // Default when the above conditions are not met
-      return 'Pending'
-
-    case TransferStatus.Complete:
-      return 'Transfer completed'
-
-    case TransferStatus.Failed:
-      return 'Transfer Failed'
-
-    default: // Should never happen
-      return 'Unknown status'
-  }
-}
-
-export function getTransferStatusToPolkadot(transferResult: ToPolkadotTransferResult) {
-  const { status, submitted } = transferResult
-
-  switch (status) {
-    case TransferStatus.Pending:
-      if (submitted) return 'Arriving at Bridge Hub'
-      return 'Pending'
-
-    case TransferStatus.Complete:
-      return 'Transfer completed'
-
-    case TransferStatus.Failed:
-      return 'Transfer Failed'
-
-    default: // Should never happen
-      return 'Unknown'
-  }
-}
-
-export function isCompletedTransfer(
-  transferResult: ToEthereumTransferResult | ToPolkadotTransferResult | SubscanXCMTransferResult,
-) {
-  return (
-    transferResult.status === TransferStatus.Complete ||
-    transferResult.status === TransferStatus.Failed
+  const transfers = await history.toPolkadotHistory(
+    assetHubScan,
+    bridgeHubScan,
+    searchRange,
+    skipLightClientUpdates,
+    bridgeHubParaId,
+    gateway,
+    ethereumProvider,
+    beacon_url,
   )
+  return transfers
 }
-
-const getTransferTimestamp = (
-  transferResult: ToEthereumTransferResult | ToPolkadotTransferResult | SubscanXCMTransferResult,
-) =>
-  /** Get transfer timestamp from Snowbridge or Subscan XCM result */
-  'info' in transferResult
-    ? transferResult.info.when.getTime()
-    : transferResult.originBlockTimestamp
-

--- a/app/src/utils/snowbridge.ts
+++ b/app/src/utils/snowbridge.ts
@@ -244,11 +244,3 @@ const getTransferTimestamp = (
     ? transferResult.info.when.getTime()
     : transferResult.originBlockTimestamp
 
-export function getErrorMessage(err: unknown) {
-  let message = 'Unknown error'
-  if (err instanceof Error) {
-    message = err.message
-  }
-  console.error(message, err)
-  return message
-}

--- a/app/src/utils/snowbridge.ts
+++ b/app/src/utils/snowbridge.ts
@@ -17,14 +17,10 @@ export async function trackFromEthTx(
     return []
   }
   const alchemyKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY
-  if (!alchemyKey) {
-    throw Error('Missing Alchemy Key')
-  }
+  if (!alchemyKey) throw Error('Missing Alchemy Key')
 
   const subscanKey = process.env.NEXT_PUBLIC_SUBSCAN_KEY
-  if (!subscanKey) {
-    throw Error('Missing Subscan Key')
-  }
+  if (!subscanKey) throw Error('Missing Subscan Key')
 
   const ethereumProvider = new AlchemyProvider(env.ethChainId, alchemyKey)
 

--- a/app/src/utils/subscan.ts
+++ b/app/src/utils/subscan.ts
@@ -14,9 +14,7 @@ export const trackFromParachainTx = async (
       return xcmTransfers
     }
     const subscanKey = process.env.NEXT_PUBLIC_SUBSCAN_KEY
-    if (!subscanKey) {
-      throw Error('Missing Subscan Key')
-    }
+    if (!subscanKey) throw Error('Missing Subscan Key')
     const relaychain = subscan.createApi(env.config.SUBSCAN_API.RELAY_CHAIN_URL, subscanKey)
 
     for (const transfer of ongoingTransfers) {

--- a/app/src/utils/subscan.ts
+++ b/app/src/utils/subscan.ts
@@ -1,10 +1,9 @@
-import { subscan } from '@snowbridge/api'
-import { environment } from '@snowbridge/api'
+import { subscan, environment } from '@snowbridge/api'
 import { TransferStatus } from '@snowbridge/api/dist/history'
 import { SubscanXCMTransferRawResponse, SubscanXCMTransferResult } from '@/models/subscan'
 import { OngoingTransferWithDirection } from '@/models/transfer'
 
-export const trackParachainTx = async (
+export const trackFromParachainTx = async (
   env: environment.SnowbridgeEnvironment,
   ongoingTransfers: OngoingTransferWithDirection[],
 ) => {

--- a/app/src/utils/transferTracking.ts
+++ b/app/src/utils/transferTracking.ts
@@ -1,8 +1,130 @@
+import { environment } from '@snowbridge/api'
+import { OngoingTransfers, StoredTransfer } from '@/models/transfer'
+import { trackFromParachainTx } from './subscan'
+import { SubscanXCMTransferResult } from '@/models/subscan'
+import { ToPolkadotTransferResult, TransferStatus } from '@snowbridge/api/dist/history'
+import { trackFromEthTx } from './snowbridge'
+
+export const trackTransfers = async (
+  env: environment.SnowbridgeEnvironment,
+  ongoingTransfers: OngoingTransfers,
+) => {
+  console.log('Fetching transfer history.')
+  const transfers: (ToPolkadotTransferResult | SubscanXCMTransferResult)[] = []
+
+  if (ongoingTransfers.toPolkadot.length) {
+    const ethToParaTx = await trackFromEthTx(env)
+    console.log('From Eth To Polkadot transfers:', ethToParaTx.length)
+    transfers.push(...ethToParaTx)
+  }
+
+  if (ongoingTransfers.toEthereum.fromAssetHub.length) {
+    const ahToEthereumTx = await trackFromParachainTx(env, ongoingTransfers.toEthereum.fromAssetHub)
+    console.log('From AH To Ethereum transfer:', ahToEthereumTx)
+    transfers.push(...ahToEthereumTx)
+  }
+
+  // Keep this until we can test tracking from Para to AH
+  if (ongoingTransfers.toEthereum.fromParachain.length) {
+    // => TODO: need to rename toEthereum => toAH/refactor object
+    const parachainToAhTx = await trackFromParachainTx(
+      env,
+      ongoingTransfers.toEthereum.fromParachain,
+    )
+    console.log('From Parachain To AH transfer:', parachainToAhTx)
+    transfers.push(...parachainToAhTx)
+  }
+
+  return transfers.sort((a, b) => getTransferTimestamp(b) - getTransferTimestamp(a))
+}
+
+const getTransferTimestamp = (
+  transferResult: ToPolkadotTransferResult | SubscanXCMTransferResult,
+) =>
+  /** Get transfer timestamp from or to prachain tx */
+  'info' in transferResult
+    ? transferResult.info.when.getTime()
+    : transferResult.originBlockTimestamp
+
+export function getTransferStatus(
+  transferResult: ToPolkadotTransferResult | SubscanXCMTransferResult,
+) {
+  /**  Checks if the transfer from or to prachain tx*/
+  const isFromParachainTx = 'destEventIndex' in transferResult && !('info' in transferResult)
+  /** Retrieves the status of a transfer from a Parachain to AH or ETH */
+  if (isFromParachainTx)
+    return getTransferStatusFromParachain(transferResult as SubscanXCMTransferResult)
+  /** Retrieves the status of a transfer from Eth to a Parachain/AH */
+  return getTransferStatusToPolkadot(transferResult as ToPolkadotTransferResult)
+}
+
+export function getTransferStatusFromParachain(transferResult: SubscanXCMTransferResult) {
+  /** Destination Event Index available */
+  const isDestEventIdxInSubscanXCMRes =
+    'destEventIndex' in transferResult && transferResult.destEventIndex.length > 0
+
+  switch (transferResult.status) {
+    case TransferStatus.Pending:
+      /** Bridge Hub Channel Message Delivered */
+      if (isDestEventIdxInSubscanXCMRes) return 'Arriving at Ethereum'
+      if (!transferResult.destEventIndex || !isDestEventIdxInSubscanXCMRes)
+        return 'Arriving at Bridge Hub'
+      // Default when the above conditions are not met
+      return 'Pending'
+
+    case TransferStatus.Complete:
+      return 'Transfer completed'
+
+    case TransferStatus.Failed:
+      return 'Transfer Failed'
+
+    default: // Should never happen
+      return 'Unknown status'
+  }
+}
+
+export function getTransferStatusToPolkadot(transferResult: ToPolkadotTransferResult) {
+  const { status, submitted } = transferResult
+
+  switch (status) {
+    case TransferStatus.Pending:
+      if (submitted) return 'Arriving at Bridge Hub'
+      return 'Pending'
+
+    case TransferStatus.Complete:
+      return 'Transfer completed'
+
+    case TransferStatus.Failed:
+      return 'Transfer Failed'
+
+    default: // Should never happen
+      return 'Unknown'
+  }
+}
+
+export function isCompletedTransfer(
+  transferResult: ToPolkadotTransferResult | SubscanXCMTransferResult,
+) {
+  return (
+    transferResult.status === TransferStatus.Complete ||
+    transferResult.status === TransferStatus.Failed
+  )
+}
+
+export const findMatchingTransfer = (
+  transfers: (ToPolkadotTransferResult | SubscanXCMTransferResult)[],
+  ongoingTransfer: StoredTransfer,
+) =>
+  transfers.find(transfer =>
+    // Transfer direction is from Eth to Parachain/AH
+    'submitted' in transfer
+      ? transfer.id === ongoingTransfer.id
+      : transfer.messageHash === ongoingTransfer.crossChainMessageHash,
+  )
+
 export function getErrorMessage(err: unknown) {
-    let message = 'Unknown error'
-    if (err instanceof Error) {
-        message = err.message
-    }
-    console.error(message, err)
-    return message
+  let message = 'Unknown error'
+  if (err instanceof Error) message = err.message
+  console.error(message, err)
+  return message
 }

--- a/app/src/utils/transferTracking.ts
+++ b/app/src/utils/transferTracking.ts
@@ -1,0 +1,8 @@
+export function getErrorMessage(err: unknown) {
+    let message = 'Unknown error'
+    if (err instanceof Error) {
+        message = err.message
+    }
+    console.error(message, err)
+    return message
+}

--- a/app/src/utils/transferTracking.ts
+++ b/app/src/utils/transferTracking.ts
@@ -20,7 +20,7 @@ export const trackTransfers = async (
 
   if (ongoingTransfers.toEthereum.fromAssetHub.length) {
     const ahToEthereumTx = await trackFromParachainTx(env, ongoingTransfers.toEthereum.fromAssetHub)
-    console.log('From AH To Ethereum transfer:', ahToEthereumTx)
+    console.log('From AH To Ethereum transfer:', ahToEthereumTx.length)
     transfers.push(...ahToEthereumTx)
   }
 
@@ -31,7 +31,7 @@ export const trackTransfers = async (
       env,
       ongoingTransfers.toEthereum.fromParachain,
     )
-    console.log('From Parachain To AH transfer:', parachainToAhTx)
+    console.log('From Parachain To AH transfer:', parachainToAhTx.length)
     transfers.push(...parachainToAhTx)
   }
 


### PR DESCRIPTION
This PR contains the first part of the transfer tracking cleaning & improvements. 

_No big logic change._ Transfers from a Parachain to Eth or AH do not rely on Snowbridge API anymore but on the Subscan direct XCM queries. Eth to Parachain/AH transfers still rely on Snowbridge API since this is the best approach. 

This first part contains a lot of files moved to a snowbridge agnostic file. _Some tests will be conducted once Bifrost to AH transfers are supported to get rid of the `const transfers: OngoingTransfers` in the history/route._

- a new utils/transfersTracking.ts that handles transfers depending on direction through `trackTx()` fn.
- utils/snowbridge.ts or utils/subscan.ts helpers (such as getErrorMessage(), getTransferStatus()…) moved to the new utils/transfersTracking.ts file.
- getTransferHistory() from utils/snowbridge.ts renamed `trackFromEthTx()` and called within the new `trackTx()` helper.
- trackXcmTransfer() from utils/subscan.ts renamed `trackParachainTx()` and called within the new `trackTx()` helper.
- removed toEthereum tracking from Snowbridge (ToEthereumTransferResult type) and replaced by` trackParachainTx()`
- useSnowbridgeTransferTracker hook => renamed to useOngoingTransfersTracker()
- findOngoingTransfer()=> renamed findMatchingTransfer() and moved to utils/transfersTracking.ts

Part 2 will onboard types update && OngoingTransfers filters improvement from the history/route.
