### PR TITLE
improvement: explorer link update

### DIFF
--- a/app/src/components/completed/TransactionDialog.tsx
+++ b/app/src/components/completed/TransactionDialog.tsx
@@ -63,7 +63,7 @@ export const TransactionDialog = ({ tx }: { tx: CompletedTransfer }) => {
                   fill={true}
                   className={cn(
                     'rounded-full border bg-background',
-                    transferSucceeded ? 'border-turtle-success-dark' : 'border-turtle-error-dark ',
+                    transferSucceeded ? 'border-turtle-success-dark' : 'border-turtle-error-dark',
                   )}
                 />
               </div>
@@ -83,7 +83,7 @@ export const TransactionDialog = ({ tx }: { tx: CompletedTransfer }) => {
                   fill={true}
                   className={cn(
                     'rounded-full border bg-background',
-                    transferSucceeded ? 'border-turtle-success-dark' : 'border-turtle-error-dark ',
+                    transferSucceeded ? 'border-turtle-success-dark' : 'border-turtle-error-dark',
                   )}
                 />
               </div>

--- a/app/src/hooks/useOngoingTransfers.tsx
+++ b/app/src/hooks/useOngoingTransfers.tsx
@@ -4,8 +4,9 @@ const useOngoingTransfers = () => {
   const ongoingTransfers = useOngoingTransfersStore(state => state.transfers)
   const addTransfer = useOngoingTransfersStore.getState().addTransfer
   const removeTransfer = useOngoingTransfersStore.getState().removeTransfer
+  const updateTransferUniqueId = useOngoingTransfersStore.getState().updateTransferUniqueId
 
-  return { ongoingTransfers, addTransfer, removeTransfer }
+  return { ongoingTransfers, addTransfer, removeTransfer, updateTransferUniqueId }
 }
 
 export default useOngoingTransfers

--- a/app/src/models/transfer.ts
+++ b/app/src/models/transfer.ts
@@ -30,6 +30,8 @@ export interface StoredTransfer extends RawTransfer {
   // TODO(nuno): we can have multiple types of transfer and have this depend on that type.
   // that way we can support different fields, for example for xcm-only transfers in the future.
   sendResult?: toEthereum.SendResult | toPolkadot.SendResult
+  // A subscan unique Id shared accross chains to track ongoing transfers
+  uniqueTrackingId?: string
 }
 
 export interface OngoingTransferWithDirection extends RawTransfer {
@@ -39,7 +41,7 @@ export interface OngoingTransferWithDirection extends RawTransfer {
 export interface OngoingTransfers {
   toEthereum: OngoingTransferWithDirection[] // AH => Eth transfer
   toPolkadot: OngoingTransferWithDirection[] // Eth => AH || Parachain transfer
-  withinPolkadot: OngoingTransferWithDirection[] // Parachain => AH transfer
+  withinPolkadot: OngoingTransferWithDirection[] // XCM transfer: Parachain to AH, AH to Parachain, Parachain to Parachain, etc
 }
 
 export interface DisplaysTransfers {

--- a/app/src/store/ongoingTransfersStore.ts
+++ b/app/src/store/ongoingTransfersStore.ts
@@ -63,18 +63,13 @@ export const useOngoingTransfersStore = create<State>()(
       updateTransferUniqueId: (id: string, uniqueTrackingId: string) => {
         if (!id || !uniqueTrackingId) return
         set(state => {
-          // Check if the newOngoingTransfer already exists in the local storage
-          if (state.transfers.some(transfer => transfer.uniqueTrackingId === uniqueTrackingId))
-            return state
-
-          state.transfers.map(transfer => {
-            if (transfer.id == id) {
-              transfer.uniqueTrackingId = uniqueTrackingId
-            }
-          })
-
           return {
-            transfers: [...state.transfers],
+            transfers: state.transfers.map(transfer => {
+              if (transfer.id == id) {
+                transfer.uniqueTrackingId = uniqueTrackingId
+              }
+              return transfer
+            }),
           }
         })
       },

--- a/app/src/store/ongoingTransfersStore.ts
+++ b/app/src/store/ongoingTransfersStore.ts
@@ -9,6 +9,7 @@ interface State {
   // Actions
   addTransfer: (transfer: StoredTransfer) => void
   removeTransfer: (id: string) => void
+  updateTransferUniqueId: (id: string, uniqueTrackingId: string) => void
 }
 
 // Serialization - Stringify function for BigInt
@@ -55,6 +56,25 @@ export const useOngoingTransfersStore = create<State>()(
 
           return {
             transfers: [...state.transfers, newOngoingTransfer],
+          }
+        })
+      },
+
+      updateTransferUniqueId: (id: string, uniqueTrackingId: string) => {
+        if (!id || !uniqueTrackingId) return
+        set(state => {
+          // Check if the newOngoingTransfer already exists in the local storage
+          if (state.transfers.some(transfer => transfer.uniqueTrackingId === uniqueTrackingId))
+            return state
+
+          state.transfers.map(transfer => {
+            if (transfer.id == id) {
+              transfer.uniqueTrackingId = uniqueTrackingId
+            }
+          })
+
+          return {
+            transfers: [...state.transfers],
           }
         })
       },

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -139,7 +139,6 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
           ? `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/polkadot-${uniqueTrackingId}`
           : `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/rococo-${uniqueTrackingId}`
 
-
       const env = getEnvironment(environment)
       if (chainId === env.config.ASSET_HUB_PARAID)
         return `${removeURLSlash(explorersUrls.subscan_assethub)}/extrinsic/${id}`

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -132,7 +132,7 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
     }
     case Network.Polkadot: {
       if (uniqueTrackingId) {
-        const path = getSubdomain(explorersUrls.subscan_relaychain)
+        const path = getSubdomainPath(explorersUrls.subscan_relaychain)
         return `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/${path}-${uniqueTrackingId}`
       }
 
@@ -148,7 +148,7 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
   }
 }
 
-export const getSubdomain = (url: string) => {
+export const getSubdomainPath = (url: string) => {
   const parsedUrl = new URL(url)
   const hostname = parsedUrl.hostname
   return hostname.split('.')[0]

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -131,6 +131,9 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
       return `${removeURLSlash(explorersUrls.etherscan)}/address/${sender}`
     }
     case Network.Polkadot: {
+      if (result?.success?.assetHub && 'submittedAtHash' in result.success.assetHub)
+        return `${removeURLSlash(explorersUrls.subscan_assethub)}/block/${result.success.assetHub.submittedAtHash}`
+
       if (uniqueTrackingId) {
         const path = getSubdomainPath(explorersUrls.subscan_relaychain)
         return `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/${path}-${uniqueTrackingId}`

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -148,9 +148,18 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
   }
 }
 
+/**
+ * Extracts and returns the subdomain from a given URL.
+ * For example,'https://polkadot.subscan.io/' input, returns 'polkadot'.
+ * @param url - The URL from which the subdomain needs to be extracted. For example, "https://sub.example.com".
+ * @returns The subdomain string from the URL.
+ */
 export const getSubdomainPath = (url: string) => {
+  // Generate a constructor URL. Example: 'https://polkadot.subscan.io/'
   const parsedUrl = new URL(url)
+  // Filter hostname from URL: 'polkadot.subscan.io/'
   const hostname = parsedUrl.hostname
+  // Split hostname & extract subdomain path: 'polkadot'
   return hostname.split('.')[0]
 }
 

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -131,9 +131,6 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
       return `${removeURLSlash(explorersUrls.etherscan)}/address/${sender}`
     }
     case Network.Polkadot: {
-      if (result?.success?.assetHub && 'submittedAtHash' in result.success.assetHub)
-        return `${removeURLSlash(explorersUrls.subscan_assethub)}/block/${result.success.assetHub.submittedAtHash}`
-
       if (uniqueTrackingId) {
         const path = getSubdomain(explorersUrls.subscan_relaychain)
         return `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/${path}-${uniqueTrackingId}`

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -134,10 +134,10 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
       if (result?.success?.assetHub && 'submittedAtHash' in result.success.assetHub)
         return `${removeURLSlash(explorersUrls.subscan_assethub)}/block/${result.success.assetHub.submittedAtHash}`
 
-      if (uniqueTrackingId)
-        return environment === Environment.Mainnet
-          ? `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/polkadot-${uniqueTrackingId}`
-          : `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/rococo-${uniqueTrackingId}`
+      if (uniqueTrackingId) {
+        const path = getSubdomain(explorersUrls.subscan_relaychain)
+        return `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/${path}-${uniqueTrackingId}`
+      }
 
       const env = getEnvironment(environment)
       if (chainId === env.config.ASSET_HUB_PARAID)
@@ -149,6 +149,12 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
     default:
       console.log(`Unsupported network: ${network}`)
   }
+}
+
+export const getSubdomain = (url: string) => {
+  const parsedUrl = new URL(url)
+  const hostname = parsedUrl.hostname
+  return hostname.split('.')[0]
 }
 
 export const txWasCancelled = (sender: Sender, error: unknown): boolean => {

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -119,20 +119,34 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
     sendResult: result,
     sender,
     id,
+    uniqueTrackingId,
   } = transfer
   const explorersUrls = EXPLORERS[environment]
   switch (network) {
     case Network.Ethereum: {
       if (result?.success?.ethereum && 'transactionHash' in result.success.ethereum)
         return `${removeURLSlash(explorersUrls.etherscan)}/tx/${result.success.ethereum.transactionHash}`
+
+      // Default Ethereum network explorer link:
       return `${removeURLSlash(explorersUrls.etherscan)}/address/${sender}`
     }
     case Network.Polkadot: {
       if (result?.success?.assetHub && 'submittedAtHash' in result.success.assetHub)
         return `${removeURLSlash(explorersUrls.subscan_assethub)}/block/${result.success.assetHub.submittedAtHash}`
       const env = getEnvironment(environment)
+
+      if (uniqueTrackingId) {
+        const explorerLink =
+          environment === Environment.Mainnet
+            ? `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/polkadot-${uniqueTrackingId}`
+            : `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/rococo-${uniqueTrackingId}`
+        return explorerLink
+      }
+
       if (chainId === env.config.ASSET_HUB_PARAID)
         return `${removeURLSlash(explorersUrls.subscan_assethub)}/extrinsic/${id}`
+
+      // Default Polkadot network explorer link:
       return `${removeURLSlash(explorersUrls.subscan_relaychain)}/account/${sender}?tab=xcm_transfer`
     }
     default:


### PR DESCRIPTION
This PR Support displaying tracking through the XCM transfers Subscan Relaychain tracking page: 
- add ongoingTransfer Store method to update the UniqueId
- optional param addition to StoredTransfer type
- implement explorer link in getExplorerLink when uniqueId is available.