### PR TITLE
fix: transfer data callback handler & subscan loop

### DIFF
--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -13925,7 +13925,7 @@ snapshots:
       '@polkadot/api-augment': 7.15.1
       '@polkadot/api-base': 7.15.1
       '@polkadot/api-derive': 7.15.1
-      '@polkadot/keyring': 8.7.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@8.7.1)
+      '@polkadot/keyring': 8.7.1(@polkadot/util-crypto@8.7.1(@polkadot/util@8.7.1))(@polkadot/util@8.7.1)
       '@polkadot/rpc-augment': 7.15.1
       '@polkadot/rpc-core': 7.15.1
       '@polkadot/rpc-provider': 7.15.1
@@ -14004,7 +14004,7 @@ snapshots:
       '@polkadot/util-crypto': 8.7.1(@polkadot/util@8.7.1)
       tslib: 2.7.0
 
-  '@polkadot/keyring@8.7.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@8.7.1)':
+  '@polkadot/keyring@8.7.1(@polkadot/util-crypto@8.7.1(@polkadot/util@8.7.1))(@polkadot/util@8.7.1)':
     dependencies:
       '@babel/runtime': 7.25.6
       '@polkadot/util': 8.7.1
@@ -14185,7 +14185,7 @@ snapshots:
   '@polkadot/rpc-provider@7.15.1':
     dependencies:
       '@babel/runtime': 7.25.6
-      '@polkadot/keyring': 8.7.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@8.7.1)
+      '@polkadot/keyring': 8.7.1(@polkadot/util-crypto@8.7.1(@polkadot/util@8.7.1))(@polkadot/util@8.7.1)
       '@polkadot/types': 7.15.1
       '@polkadot/types-support': 7.15.1
       '@polkadot/util': 8.7.1
@@ -14359,7 +14359,7 @@ snapshots:
   '@polkadot/types@7.15.1':
     dependencies:
       '@babel/runtime': 7.25.6
-      '@polkadot/keyring': 8.7.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@8.7.1)
+      '@polkadot/keyring': 8.7.1(@polkadot/util-crypto@8.7.1(@polkadot/util@8.7.1))(@polkadot/util@8.7.1)
       '@polkadot/types-augment': 7.15.1
       '@polkadot/types-codec': 7.15.1
       '@polkadot/types-create': 7.15.1

--- a/app/src/components/completed/TransactionDialog.tsx
+++ b/app/src/components/completed/TransactionDialog.tsx
@@ -63,7 +63,7 @@ export const TransactionDialog = ({ tx }: { tx: CompletedTransfer }) => {
                   fill={true}
                   className={cn(
                     'rounded-full border bg-background',
-                    transferSucceeded ? 'border-turtle-success-dark' : 'border-turtle-error-dark ',
+                    transferSucceeded ? 'border-turtle-success-dark' : 'border-turtle-error-dark',
                   )}
                 />
               </div>
@@ -83,7 +83,7 @@ export const TransactionDialog = ({ tx }: { tx: CompletedTransfer }) => {
                   fill={true}
                   className={cn(
                     'rounded-full border bg-background',
-                    transferSucceeded ? 'border-turtle-success-dark' : 'border-turtle-error-dark ',
+                    transferSucceeded ? 'border-turtle-success-dark' : 'border-turtle-error-dark',
                   )}
                 />
               </div>

--- a/app/src/hooks/useAssetTransferApi.tsx
+++ b/app/src/hooks/useAssetTransferApi.tsx
@@ -68,7 +68,7 @@ const useAssetTransferApi = () => {
           if (!txHash) throw new Error('Transfer error: Failed to generate the transaction hash')
           if (isComplete) return
 
-          // Wait until block to be finalized before handling transfer data
+          // Wait until block is finalized before handling transfer data
           if (status.isFinalized) {
             let messageHash: string | undefined
             let messageId: string | undefined

--- a/app/src/hooks/useAssetTransferApi.tsx
+++ b/app/src/hooks/useAssetTransferApi.tsx
@@ -62,21 +62,20 @@ const useAssetTransferApi = () => {
         .tx(txResult.tx)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .signAndSend(account.address, { signer: account.signer as any }, async result => {
+          const { txHash, status, events } = result
+
           // verify transaction hash & transfer isn't completed
-          if (!result.txHash)
-            throw new Error('Transfer error: Failed to generate the transaction hash')
+          if (!txHash) throw new Error('Transfer error: Failed to generate the transaction hash')
           if (isComplete) return
 
-          const isIncluded = result.status.isInBlock
-          // const isFinalized = result.status.isFinalized
-          if (isIncluded) {
-            // if (isIncluded || isFinalized) {
+          // Wait until block to be finalized before handling transfer data
+          if (status.isFinalized) {
             let messageHash: string | undefined
             let messageId: string | undefined
             let extrinsicSuccess: boolean = false
 
             // Filter the events to get the needed data
-            result.events.forEach(({ event: { data, method, section } }) => {
+            events.forEach(({ event: { data, method, section } }) => {
               if (
                 method === 'XcmpMessageSent' &&
                 section === 'xcmpQueue' &&
@@ -107,7 +106,7 @@ const useAssetTransferApi = () => {
             const date = new Date()
 
             addTransferToStorage({
-              id: result.txHash.toString(),
+              id: txHash.toString(),
               sourceChain,
               token,
               tokenUSDValue,

--- a/app/src/utils/subscan.ts
+++ b/app/src/utils/subscan.ts
@@ -9,10 +9,7 @@ export const trackFromParachainTx = async (
 ) => {
   try {
     const xcmTransfers: FromParachainTrackingResult[] = []
-    if (!env.config.SUBSCAN_API) {
-      console.warn(`No subscan api urls configured for ${env.name}`)
-      return xcmTransfers
-    }
+    if (!env.config.SUBSCAN_API) throw Error(`No subscan api urls configured for ${env.name}`)
     const subscanKey = process.env.NEXT_PUBLIC_SUBSCAN_KEY
     if (!subscanKey) throw Error('Missing Subscan Key')
     const relaychain = subscan.createApi(env.config.SUBSCAN_API.RELAY_CHAIN_URL, subscanKey)
@@ -22,7 +19,7 @@ export const trackFromParachainTx = async (
       if (!crossChainMessageHash) {
         console.log('Cross chain message undefined')
         // Should not return an error as we want to continue looping to the others transfers
-        return xcmTransfers
+        continue
       }
 
       const query = await relaychain.post('api/scan/xcm/list', {
@@ -32,14 +29,14 @@ export const trackFromParachainTx = async (
       if (query.status !== 200) {
         console.log('Subscan API request failed')
         // Should not return an error as we want to continue looping to the others transfers
-        return xcmTransfers
+        continue
       }
 
       const transferData: SubscanTransferResponse[] = query.json?.data?.list ?? []
       if (!transferData.length || !transferData[0]) {
         console.log(`No XCM transfer data found for message hash ${crossChainMessageHash}`)
         // Should not return an error as we want to continue looping to the others transfers
-        return xcmTransfers
+        continue
       }
 
       let xchainTransferStatus: number = 1


### PR DESCRIPTION
This PR fix the following: 

- The transfer data handling within the AT API callback: switch transfer result status check from isInBlock to isFinalized. It should prevent registering a first bunch of data that changes once block data is finalized.

- Fixes Subscan, exiting loop too early when an ongoing transfer fails. 
