### PR TITLE
Fix/tracking from snowbridge api

### DIFF
--- a/app/src/config/registry.ts
+++ b/app/src/config/registry.ts
@@ -385,7 +385,7 @@ export const testnetRegistry: Registry = {
       from: Testnet.RococoAssetHub.uid,
       to: Testnet.Sepolia.uid,
       tokens: [Testnet.WETH.id, Testnet.VETH.id],
-      sdk: 'AssetTransferApi',
+      sdk: 'SnowbridgeApi',
     },
   ],
 }

--- a/app/src/models/snowbridge.ts
+++ b/app/src/models/snowbridge.ts
@@ -6,3 +6,4 @@ export type SnowbridgeStatus = {
 }
 
 export type FromEthTrackingResult = history.ToPolkadotTransferResult
+export type FromAhToEthTrackingResult = history.ToEthereumTransferResult

--- a/app/src/models/transfer.ts
+++ b/app/src/models/transfer.ts
@@ -5,7 +5,7 @@ import { Environment } from '@/store/environmentStore'
 
 import { Chain } from './chain'
 import { FromParachainTrackingResult } from './subscan'
-import { FromEthTrackingResult } from './snowbridge'
+import { FromEthTrackingResult, FromAhToEthTrackingResult } from './snowbridge'
 import { Token } from './token'
 
 export interface RawTransfer {
@@ -90,4 +90,6 @@ export enum TransferTab {
 }
 export type TransferTabOptions = TransferTab
 
-export type TxTrackingResult = FromEthTrackingResult | FromParachainTrackingResult
+export type TxTrackingResult =
+  // Snowbridge API | Snowbridge API | Subscan API
+  FromEthTrackingResult | FromAhToEthTrackingResult | FromParachainTrackingResult

--- a/app/src/utils/snowbridge.ts
+++ b/app/src/utils/snowbridge.ts
@@ -1,7 +1,7 @@
 import { AlchemyProvider } from 'ethers'
 import { environment, subscan, history } from '@snowbridge/api'
-import { IGateway__factory } from '@snowbridge/contract-types'
-import { FromEthTrackingResult } from '@/models/snowbridge'
+import { BeefyClient__factory, IGateway__factory } from '@snowbridge/contract-types'
+import { FromAhToEthTrackingResult, FromEthTrackingResult } from '@/models/snowbridge'
 
 export const SKIP_LIGHT_CLIENT_UPDATES = true
 export const HISTORY_IN_SECONDS = 60 * 60 * 24 * 2 // 2 days
@@ -48,9 +48,7 @@ export async function trackFromEthTx(
     utcNowTimestamp - historyInSeconds,
   )
 
-  if (ethNowBlock === null) {
-    throw Error('Could not fetch latest Ethereum block.')
-  }
+  if (ethNowBlock === null) throw Error('Could not fetch latest Ethereum block.')
 
   const searchRange = {
     assetHub: {
@@ -76,6 +74,77 @@ export async function trackFromEthTx(
     gateway,
     ethereumProvider,
     beacon_url,
+  )
+  return transfers
+}
+
+export async function trackFromAhToEthTx(
+  env: environment.SnowbridgeEnvironment,
+  skipLightClientUpdates = SKIP_LIGHT_CLIENT_UPDATES,
+  historyInSeconds = HISTORY_IN_SECONDS,
+): Promise<FromAhToEthTrackingResult[]> {
+  if (!env.config.SUBSCAN_API) {
+    console.warn(`No subscan api urls configured for ${env.name}`)
+    return []
+  }
+  const alchemyKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY
+  if (!alchemyKey) throw Error('Missing Alchemy Key')
+
+  const subscanKey = process.env.NEXT_PUBLIC_SUBSCAN_KEY
+  if (!subscanKey) throw Error('Missing Subscan Key')
+
+  const ethereumProvider = new AlchemyProvider(env.ethChainId, alchemyKey)
+
+  const assetHubScan = subscan.createApi(env.config.SUBSCAN_API.ASSET_HUB_URL, subscanKey)
+  const bridgeHubScan = subscan.createApi(env.config.SUBSCAN_API.BRIDGE_HUB_URL, subscanKey)
+  const relaychainScan = subscan.createApi(env.config.SUBSCAN_API.RELAY_CHAIN_URL, subscanKey)
+  const assetHubParaId = env.config.ASSET_HUB_PARAID
+  const beefyClient = BeefyClient__factory.connect(env.config.BEEFY_CONTRACT, ethereumProvider)
+  const gateway = IGateway__factory.connect(env.config.GATEWAY_CONTRACT, ethereumProvider)
+  const ethereumSearchPeriodBlocks = historyInSeconds / ETHEREUM_BLOCK_TIME_SECONDS
+
+  const ethNowBlock = await ethereumProvider.getBlock('latest', false)
+  const now = new Date()
+  const utcNowTimestamp = Math.floor(now.getTime() / 1000)
+
+  const toAssetHubBlock = await subscan.fetchBlockNearTimestamp(assetHubScan, utcNowTimestamp)
+  const fromAssetHubBlock = await subscan.fetchBlockNearTimestamp(
+    assetHubScan,
+    utcNowTimestamp - historyInSeconds,
+  )
+  const toBridgeHubBlock = await subscan.fetchBlockNearTimestamp(bridgeHubScan, utcNowTimestamp)
+  const fromBridgeHubBlock = await subscan.fetchBlockNearTimestamp(
+    bridgeHubScan,
+    utcNowTimestamp - historyInSeconds,
+  )
+
+  if (ethNowBlock === null) throw Error('Could not fetch latest Ethereum block.')
+
+  const searchRange = {
+    assetHub: {
+      fromBlock: fromAssetHubBlock.block_num,
+      toBlock: toAssetHubBlock.block_num,
+    },
+    bridgeHub: {
+      fromBlock: fromBridgeHubBlock.block_num,
+      toBlock: toBridgeHubBlock.block_num,
+    },
+    ethereum: {
+      fromBlock: ethNowBlock.number - ethereumSearchPeriodBlocks,
+      toBlock: ethNowBlock.number,
+    },
+  }
+
+  const transfers = await history.toEthereumHistory(
+    assetHubScan,
+    bridgeHubScan,
+    relaychainScan,
+    searchRange,
+    skipLightClientUpdates,
+    env.ethChainId,
+    assetHubParaId,
+    beefyClient,
+    gateway,
   )
   return transfers
 }

--- a/app/src/utils/snowbridge.ts
+++ b/app/src/utils/snowbridge.ts
@@ -4,7 +4,7 @@ import { BeefyClient__factory, IGateway__factory } from '@snowbridge/contract-ty
 import { FromAhToEthTrackingResult, FromEthTrackingResult } from '@/models/snowbridge'
 
 export const SKIP_LIGHT_CLIENT_UPDATES = true
-export const HISTORY_IN_SECONDS = 60 * 60 * 24 * 2 // 2 days
+export const HISTORY_IN_SECONDS = 60 * 60 * 24 * 5 // 5 days
 export const ETHEREUM_BLOCK_TIME_SECONDS = 12
 export const ACCEPTABLE_BRIDGE_LATENCY = 28800 // 8 hours
 

--- a/app/src/utils/snowbridge.ts
+++ b/app/src/utils/snowbridge.ts
@@ -4,7 +4,7 @@ import { BeefyClient__factory, IGateway__factory } from '@snowbridge/contract-ty
 import { FromAhToEthTrackingResult, FromEthTrackingResult } from '@/models/snowbridge'
 
 export const SKIP_LIGHT_CLIENT_UPDATES = true
-export const HISTORY_IN_SECONDS = 60 * 60 * 24 * 5 // 5 days
+export const HISTORY_IN_SECONDS = 60 * 60 * 24 * 3 // 3 days
 export const ETHEREUM_BLOCK_TIME_SECONDS = 12
 export const ACCEPTABLE_BRIDGE_LATENCY = 28800 // 8 hours
 
@@ -13,10 +13,8 @@ export async function trackFromEthTx(
   skipLightClientUpdates = SKIP_LIGHT_CLIENT_UPDATES,
   historyInSeconds = HISTORY_IN_SECONDS,
 ): Promise<FromEthTrackingResult[]> {
-  if (!env.config.SUBSCAN_API) {
-    console.warn(`No subscan api urls configured for ${env.name}`)
-    return []
-  }
+  if (!env.config.SUBSCAN_API) throw Error(`No subscan api urls configured for ${env.name}`)
+
   const alchemyKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY
   if (!alchemyKey) throw Error('Missing Alchemy Key')
 
@@ -83,10 +81,8 @@ export async function trackFromAhToEthTx(
   skipLightClientUpdates = SKIP_LIGHT_CLIENT_UPDATES,
   historyInSeconds = HISTORY_IN_SECONDS,
 ): Promise<FromAhToEthTrackingResult[]> {
-  if (!env.config.SUBSCAN_API) {
-    console.warn(`No subscan api urls configured for ${env.name}`)
-    return []
-  }
+  if (!env.config.SUBSCAN_API) throw Error(`No subscan api urls configured for ${env.name}`)
+
   const alchemyKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY
   if (!alchemyKey) throw Error('Missing Alchemy Key')
 

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -131,8 +131,12 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
       return `${removeURLSlash(explorersUrls.etherscan)}/address/${sender}`
     }
     case Network.Polkadot: {
-      if (result?.success?.assetHub && 'txHash' in result.success.assetHub)
-        return `${removeURLSlash(explorersUrls.subscan_assethub)}/extrinsic/${result.success.assetHub.txHash}`
+      const txHash =
+        result?.success?.assetHub && 'txHash' in result.success.assetHub
+          ? result.success.assetHub.txHash
+          : undefined
+      if (txHash) return `${removeURLSlash(explorersUrls.subscan_assethub)}/extrinsic/${txHash}`
+
       if (uniqueTrackingId) {
         const path = getSubdomainPath(explorersUrls.subscan_relaychain)
         return `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/${path}-${uniqueTrackingId}`

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -131,9 +131,8 @@ export function getExplorerLink(transfer: StoredTransfer): string | undefined {
       return `${removeURLSlash(explorersUrls.etherscan)}/address/${sender}`
     }
     case Network.Polkadot: {
-      if (result?.success?.assetHub && 'submittedAtHash' in result.success.assetHub)
-        return `${removeURLSlash(explorersUrls.subscan_assethub)}/block/${result.success.assetHub.submittedAtHash}`
-
+      if (result?.success?.assetHub && 'txHash' in result.success.assetHub)
+        return `${removeURLSlash(explorersUrls.subscan_assethub)}/extrinsic/${result.success.assetHub.txHash}`
       if (uniqueTrackingId) {
         const path = getSubdomainPath(explorersUrls.subscan_relaychain)
         return `${removeURLSlash(explorersUrls.subscan_relaychain)}/xcm_message/${path}-${uniqueTrackingId}`

--- a/app/src/utils/transferTracking.ts
+++ b/app/src/utils/transferTracking.ts
@@ -37,7 +37,7 @@ export const trackTransfers = async (
 /**
  * Retrieves the transfer timestamp.
  * A transfer result from the Snowbridge API includes 'info' in the transferResult and covers:
- * both Eth => Parachain and AH => Eth transfer directions.
+ * both Eth to Parachain and AH to Eth transfer directions.
  *
  * The second condition returns the timestamp from an AT API transfer result.
  * @param txTrackingResult - A transfer tracking response from the Snowbridge API or Subscan API.
@@ -62,7 +62,7 @@ const getTransferTimestamp = (txTrackingResult: TxTrackingResult) =>
  * @returns the transfer status as string
  */
 export function getTransferStatus(transferResult: TxTrackingResult) {
-  // Checks if the tracked AH => Ethereum transfer comes from Snowbridge API.
+  // Checks if the tracked AH to Ethereum transfer comes from Snowbridge API.
   const isAhToEthTransfer =
     'info' in transferResult && transferResult.info.destinationParachain == undefined
 
@@ -79,8 +79,8 @@ export function getTransferStatus(transferResult: TxTrackingResult) {
 
 /**
  * Retrieves the status of a transfer from:
- * A Parachain => AH (initiated with AT API and tracked with Subscan API)
- * The AH Parachain => Eth (initiated and tracked w Snowbridge API)
+ * A Parachain to AH (initiated with AT API and tracked with Subscan API)
+ * The AH Parachain to Eth (initiated and tracked w Snowbridge API)
  *
  * @param txTrackingResult - A Eth to Parachain/AH transfer tracking response from the Snowbridge API.
  * @returns the transfer status as string
@@ -166,8 +166,8 @@ export function isCompletedTransfer(txTrackingResult: TxTrackingResult) {
  * Finding a match relies on either the Snowbridge API or the AT API, and depends on the transfer direction.
  *
  * An ongoing transfer result from the Snowbridge API includes 'submitted' in the transferResult.
- * AH => Eth transfer direction includes 'extrinsic_hash' in its response.
- * The second condition finds a matching transfer for the Eth => Parachain direction.
+ * AH to Eth transfer direction includes 'extrinsic_hash' in its response.
+ * The second condition finds a matching transfer for the Eth to Parachain direction.
  *
  * If the ongoing transfer does not rely on the Snowbridge API but instead on the AT API, the ongoingTransfer covers an XCM transfer direction.
  *

--- a/app/src/utils/transferTracking.ts
+++ b/app/src/utils/transferTracking.ts
@@ -3,14 +3,13 @@ import { OngoingTransfers, StoredTransfer, TxTrackingResult } from '@/models/tra
 import { trackFromParachainTx } from './subscan'
 import { FromParachainTrackingResult } from '@/models/subscan'
 import { TransferStatus } from '@snowbridge/api/dist/history'
-import { trackFromEthTx } from './snowbridge'
-import { FromEthTrackingResult } from '@/models/snowbridge'
+import { trackFromEthTx, trackFromAhToEthTx } from './snowbridge'
+import { FromAhToEthTrackingResult, FromEthTrackingResult } from '@/models/snowbridge'
 
 export const trackTransfers = async (
   env: environment.SnowbridgeEnvironment,
   ongoingTransfers: OngoingTransfers,
 ) => {
-  console.log('Fetching transfer history.')
   const transfers: TxTrackingResult[] = []
 
   if (ongoingTransfers.toPolkadot.length) {
@@ -20,7 +19,7 @@ export const trackTransfers = async (
   }
 
   if (ongoingTransfers.toEthereum.length) {
-    const ahToEthereumTx = await trackFromParachainTx(env, ongoingTransfers.toEthereum)
+    const ahToEthereumTx = await trackFromAhToEthTx(env)
     console.log('From AH To Ethereum transfer:', ahToEthereumTx.length)
     transfers.push(...ahToEthereumTx)
   }
@@ -35,31 +34,79 @@ export const trackTransfers = async (
   return transfers.sort((a, b) => getTransferTimestamp(b) - getTransferTimestamp(a))
 }
 
-const getTransferTimestamp = (transferResult: TxTrackingResult) =>
-  /** Get transfer timestamp from or to prachain tx */
-  'info' in transferResult
-    ? transferResult.info.when.getTime()
-    : transferResult.originBlockTimestamp
+/**
+ * Retrieves the transfer timestamp.
+ * A transfer result from the Snowbridge API includes 'info' in the transferResult and covers:
+ * both Eth => Parachain and AH => Eth transfer directions.
+ *
+ * The second condition returns the timestamp from an AT API transfer result.
+ * @param txTrackingResult - A transfer tracking response from the Snowbridge API or Subscan API.
+ * @returns the transfer timestamp in milliseconds.
+ */
+const getTransferTimestamp = (txTrackingResult: TxTrackingResult) =>
+  'info' in txTrackingResult
+    ? txTrackingResult.info.when.getTime()
+    : txTrackingResult.originBlockTimestamp
 
+/**
+ * Provides the current transfer status.
+ * If a result includes 'info' in the transferResult and info.destinationParachain is undefnied:
+ * The transfer direction is from AH to Eth (from Snowbridge API)
+ *
+ * If a result includes 'destEventIndex' in the transferResult and info is undefnied:
+ * The transfer direction is from a Parachain to AH (from AT API)
+ *
+ * Default case return get transfer status for a transfer from Eth to a Parachain/AH
+ *
+ * @param txTrackingResult - A transfer tracking response from the Snowbridge API or Subscan API.
+ * @returns the transfer status as string
+ */
 export function getTransferStatus(transferResult: TxTrackingResult) {
-  /**  Checks if the transfer from or to prachain tx*/
-  const isFromParachainTx = 'destEventIndex' in transferResult && !('info' in transferResult)
-  /** Retrieves the status of a transfer from a Parachain to AH or ETH */
-  if (isFromParachainTx) return getTransferStatusFromParachain(transferResult)
-  /** Retrieves the status of a transfer from Eth to a Parachain/AH */
-  return getTransferStatusToPolkadot(transferResult)
+  // Checks if the tracked AH => Ethereum transfer comes from Snowbridge API.
+  const isAhToEthTransfer =
+    'info' in transferResult && transferResult.info.destinationParachain == undefined
+
+  // Checks if the tracked XCM transfer comes from Subscan API.
+  const isXCMTransfer = 'destEventIndex' in transferResult && !('info' in transferResult)
+
+  if (isAhToEthTransfer)
+    return getTransferStatusFromParachain(transferResult as FromAhToEthTrackingResult)
+  if (isXCMTransfer)
+    return getTransferStatusFromParachain(transferResult as FromParachainTrackingResult)
+  // Retrieves the status of a transfer from Eth to a Parachain/AH (from Snowbridge API)
+  return getTransferStatusToPolkadot(transferResult as FromEthTrackingResult)
 }
 
-export function getTransferStatusFromParachain(transferResult: FromParachainTrackingResult) {
+/**
+ * Retrieves the status of a transfer from:
+ * A Parachain => AH (initiated with AT API and tracked with Subscan API)
+ * The AH Parachain => Eth (initiated and tracked w Snowbridge API)
+ *
+ * @param txTrackingResult - A Eth to Parachain/AH transfer tracking response from the Snowbridge API.
+ * @returns the transfer status as string
+ */
+export function getTransferStatusFromParachain(
+  transferResult: FromAhToEthTrackingResult | FromParachainTrackingResult,
+) {
+  /** Bridge Hub Channel Message Delivered */
+  const isBHChannelMsgDeliveredInSnowbridgeRes =
+    'bridgeHubChannelDelivered' in transferResult &&
+    transferResult.bridgeHubChannelDelivered?.success
   /** Destination Event Index available */
   const isDestEventIdxInSubscanXCMRes =
     'destEventIndex' in transferResult && transferResult.destEventIndex.length > 0
+  /** Transfer just submitted from AH */
+  const isTransferSubmittedInSnowbridgeRes = 'submitted' in transferResult
 
   switch (transferResult.status) {
     case TransferStatus.Pending:
-      /** Bridge Hub Channel Message Delivered */
-      if (isDestEventIdxInSubscanXCMRes) return 'Arriving at Ethereum'
-      if (!transferResult.destEventIndex || !isDestEventIdxInSubscanXCMRes)
+      if (isBHChannelMsgDeliveredInSnowbridgeRes || isDestEventIdxInSubscanXCMRes)
+        return 'Arriving at Ethereum'
+      if (
+        isTransferSubmittedInSnowbridgeRes ||
+        !transferResult.destEventIndex ||
+        !isDestEventIdxInSubscanXCMRes
+      )
         return 'Arriving at Bridge Hub'
       // Default when the above conditions are not met
       return 'Pending'
@@ -75,8 +122,15 @@ export function getTransferStatusFromParachain(transferResult: FromParachainTrac
   }
 }
 
-export function getTransferStatusToPolkadot(transferResult: FromEthTrackingResult) {
-  const { status, submitted } = transferResult
+/**
+ * Retrieves the status of a transfer from:
+ * Eth to a Parachain/AH (initiated and tracked w Snowbridge API)
+ *
+ * @param txTrackingResult - A Eth to Parachain/AH transfer tracking response from the Snowbridge API.
+ * @returns the transfer status as string
+ */
+export function getTransferStatusToPolkadot(txTrackingResult: FromEthTrackingResult) {
+  const { status, submitted } = txTrackingResult
 
   switch (status) {
     case TransferStatus.Pending:
@@ -94,21 +148,42 @@ export function getTransferStatusToPolkadot(transferResult: FromEthTrackingResul
   }
 }
 
-export function isCompletedTransfer(transferResult: TxTrackingResult) {
+/**
+ * Verifies if a transfer is completed
+ *
+ * @param txTrackingResult - A transfer tracking response from the Snowbridge API or Subscan API.
+ * @returns a boolean: false is transfer is still pending, true is transfer has failed or completed.
+ */
+export function isCompletedTransfer(txTrackingResult: TxTrackingResult) {
   return (
-    transferResult.status === TransferStatus.Complete ||
-    transferResult.status === TransferStatus.Failed
+    txTrackingResult.status === TransferStatus.Complete ||
+    txTrackingResult.status === TransferStatus.Failed
   )
 }
 
+/**
+ * Finds a matching ongoingTransfer stored in the user's local storage within the tracking explorer/history transfer list (Subscan, Snowbridge history, etc.).
+ * Finding a match relies on either the Snowbridge API or the AT API, and depends on the transfer direction.
+ *
+ * An ongoing transfer result from the Snowbridge API includes 'submitted' in the transferResult.
+ * AH => Eth transfer direction includes 'extrinsic_hash' in its response.
+ * The second condition finds a matching transfer for the Eth => Parachain direction.
+ *
+ * If the ongoing transfer does not rely on the Snowbridge API but instead on the AT API, the ongoingTransfer covers an XCM transfer direction.
+ *
+ * @param transfers - the transfers tracking history list from explorers.
+ * @param ongoingTransfer -An ongoingTransfer stored in the user's local storage.
+ * @returns The matching transfer from the explorer history list.
+ */
 export const findMatchingTransfer = (
   transfers: TxTrackingResult[],
   ongoingTransfer: StoredTransfer,
 ) =>
   transfers.find(transfer =>
-    // Transfer direction is from Eth to Parachain/AH
     'submitted' in transfer
-      ? transfer.id === ongoingTransfer.id
+      ? 'extrinsic_hash' in transfer.submitted
+        ? transfer.submitted.extrinsic_hash === ongoingTransfer.id
+        : transfer.id === ongoingTransfer.id
       : transfer.messageHash === ongoingTransfer.crossChainMessageHash,
   )
 

--- a/app/src/utils/transferTracking.ts
+++ b/app/src/utils/transferTracking.ts
@@ -40,8 +40,8 @@ export const trackTransfers = async (
  * both Eth to Parachain and AH to Eth transfer directions.
  *
  * The second condition returns the timestamp from an AT API transfer result.
- * @param {TxTrackingResult} txTrackingResult - A transfer tracking response from the Snowbridge API or Subscan API.
- * @returns {number} - The transfer timestamp in milliseconds.
+ * @param txTrackingResult - A transfer tracking response from the Snowbridge API or Subscan API.
+ * @returns - The transfer timestamp in milliseconds.
  */
 const getTransferTimestamp = (txTrackingResult: TxTrackingResult) =>
   'info' in txTrackingResult
@@ -59,8 +59,8 @@ const getTransferTimestamp = (txTrackingResult: TxTrackingResult) =>
  *
  * Default case return get transfer status for a transfer from Eth to a Parachain/AH
  *
- * @param {TxTrackingResult} transferResult - A transfer tracking response from the Snowbridge API or Subscan API.
- * @returns {string} - the transfer status
+ * @param transferResult - A transfer tracking response from the Snowbridge API or Subscan API.
+ * @returns - the transfer status
  */
 export function getTransferStatus(transferResult: TxTrackingResult) {
   // Checks if the tracked AH to Ethereum transfer comes from Snowbridge API.
@@ -83,8 +83,8 @@ export function getTransferStatus(transferResult: TxTrackingResult) {
  * The AH Parachain to Eth (initiated and tracked with Snowbridge API)
  * A Parachain to AH (initiated with AT API and tracked with Subscan API)
  *
- * @param {FromAhToEthTrackingResult | FromParachainTrackingResult} transferResult - The transfer tracking response from either the Subscan API (for Parachain to AH transfers) or the Snowbridge API (for AH to Ethereum transfers).
- * @returns {string} - the transfer status
+ * @param transferResult - The transfer tracking response from either the Subscan API (for Parachain to AH transfers) or the Snowbridge API (for AH to Ethereum transfers).
+ * @returns - the transfer status
  */
 export function getTransferStatusFromParachain(
   transferResult: FromAhToEthTrackingResult | FromParachainTrackingResult,
@@ -127,8 +127,8 @@ export function getTransferStatusFromParachain(
  * Retrieves the status of a transfer from:
  * Eth to a Parachain/AH (initiated and tracked w Snowbridge API)
  *
- * @param {FromEthTrackingResult} txTrackingResult - The transfer tracking response for an Eth to Parachain/AH transfer from the Snowbridge API.
- * @returns {string} - the transfer status
+ * @param txTrackingResult - The transfer tracking response for an Eth to Parachain/AH transfer from the Snowbridge API.
+ * @returns - the transfer status
  */
 export const getTransferStatusToPolkadot = (txTrackingResult: FromEthTrackingResult) => {
   const { status, submitted } = txTrackingResult
@@ -152,8 +152,8 @@ export const getTransferStatusToPolkadot = (txTrackingResult: FromEthTrackingRes
 /**
  * Verifies if a transfer is completed
  *
- * @param {TxTrackingResult} txTrackingResult - The transfer tracking response from the Snowbridge API, Subscan API, or other explorer services.
- * @returns {boolean} - `true` if the transfer has either completed or failed, otherwise `false` if it is still pending.
+ * @param txTrackingResult - The transfer tracking response from the Snowbridge API, Subscan API, or other explorer services.
+ * @returns - `true` if the transfer has either completed or failed, otherwise `false` if it is still pending.
  */
 export const isCompletedTransfer = (txTrackingResult: TxTrackingResult) => {
   return (
@@ -171,9 +171,9 @@ export const isCompletedTransfer = (txTrackingResult: TxTrackingResult) => {
  * - AT API:
  *   - Used for transfers in the XCM direction.
  *
- * @param {TxTrackingResult[]} transfers - The list of tracked transfers from the explorer's history (Subscan, Snowbridge history, etc.).
- * @param {StoredTransfer} ongoingTransfer - The ongoing transfer stored in the user's local storage.
- * @returns {TxTrackingResult | undefined} - The matching transfer from the explorer history list, or `undefined` if no match is found.
+ * @param transfers - The list of tracked transfers from the explorer's history (Subscan, Snowbridge history, etc.).
+ * @param ongoingTransfer - The ongoing transfer stored in the user's local storage.
+ * @returns - The matching transfer from the explorer history list, or `undefined` if no match is found.
  */
 export const findMatchingTransfer = (
   transfers: TxTrackingResult[],


### PR DESCRIPTION
This PR revert some changes to support AH to Eth transfer using Snowbridge API. 

The `trackFromAhToEthTx()` is the same code as we used before but in a dedicated helper. 
It contains more documentation about helpers as well. 