### PR TITLE
fix: Simplify credits by removing logos

### DIFF
--- a/app/src/components/Credits.tsx
+++ b/app/src/components/Credits.tsx
@@ -1,40 +1,19 @@
-import Image from 'next/image'
 import { FC } from 'react'
 
 const Credits: FC = () => {
   return (
-    <div className="credits mt-6 flex flex-row items-center justify-center text-xs text-turtle-level5 sm:text-sm">
+    <div className="credits mt-6 text-center text-xs text-turtle-level5">
       Made with love by{' '}
-      <a
-        href="https://www.velocitylabs.org"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="px-2"
-      >
-        <Image
-          src={'/velocitylabs.svg'}
-          alt={'Velocity Labs'}
-          width={24}
-          height={24}
-          className="rounded-full border-1"
-        />
+      <a href="https://www.velocitylabs.org" target="_blank" rel="noopener noreferrer">
+        Velocity Labs
       </a>
-      {' ・ '}
-      Powered by{' '}
-      <a
-        href="https://docs.snowbridge.network/"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="px-2"
-      >
-        <Image
-          src={'/snowbridge.svg'}
-          alt={'Snowbridge Network'}
-          width={24}
-          height={24}
-          className="rounded-full border-1"
-        />
-      </a>
+      <span className="hidden md:inline">{' ・ '}</span>
+      <div className="mt-2 sm:block md:inline">
+        Powered by{' '}
+        <a href="https://docs.snowbridge.network" target="_blank" rel="noopener noreferrer">
+          Snowbridge
+        </a>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Desktop:
<img width="586" alt="Screenshot 2024-10-23 at 10 13 22" src="https://github.com/user-attachments/assets/3e2e7659-f25a-4067-818f-c98c2f65ee18">

Mobile:
<img width="480" alt="Screenshot 2024-10-23 at 10 13 27" src="https://github.com/user-attachments/assets/77bf5d83-37f2-4d04-9030-bb743a925418">
