### PR TITLE
feat ⚡ integrate paraspell xcm fee preview + add relay <-> AH route

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "@chainsafe/cypress-polkadot-wallet": "^2.2.0",
     "@hookform/resolvers": "3.9.0",
     "@nextui-org/react": "^2.4.8",
-    "@paraspell/sdk": "^6.2.2",
+    "@paraspell/sdk": "^6.2.3",
     "@polkadot-api/descriptors": "file:.papi/descriptors",
     "@polkadot/api": "^14.0.1",
     "@polkadot/api-base": "^14.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "@chainsafe/cypress-polkadot-wallet": "^2.2.0",
     "@hookform/resolvers": "3.9.0",
     "@nextui-org/react": "^2.4.8",
-    "@paraspell/sdk": "^6.2.1",
+    "@paraspell/sdk": "^6.2.2",
     "@polkadot-api/descriptors": "file:.papi/descriptors",
     "@polkadot/api": "^14.0.1",
     "@polkadot/api-base": "^14.0.1",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^2.4.8
         version: 2.4.8(@types/react@18.3.9)(framer-motion@11.9.0(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@20.16.9)(typescript@5.6.2)))
       '@paraspell/sdk':
-        specifier: ^6.2.1
-        version: 6.2.1(@polkadot/api-base@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/api@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/apps-config@0.145.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@5.0.10))(@polkadot/types@14.0.1)(@polkadot/util@13.1.1)(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
+        specifier: ^6.2.2
+        version: 6.2.2(@polkadot/api-base@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/api@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/apps-config@0.145.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@5.0.10))(@polkadot/types@14.0.1)(@polkadot/util@13.1.1)(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
       '@polkadot-api/descriptors':
         specifier: file:.papi/descriptors
         version: file:.papi/descriptors(polkadot-api@1.3.3(bufferutil@4.0.8)(jiti@2.0.0)(postcss@8.4.47)(rxjs@7.8.1)(smoldot@2.0.22(bufferutil@4.0.8)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)(yaml@2.5.1))
@@ -2441,8 +2441,8 @@ packages:
   '@parallel-finance/type-definitions@2.0.1':
     resolution: {integrity: sha512-fC1QfhFFd8oSZqdIh6kmoMNvTxZdQGw1sTAbdYSINyVxyCxKiDg47ZP9bAZFDexL7POqnXnn4pYM7kUAnsT+8Q==}
 
-  '@paraspell/sdk@6.2.1':
-    resolution: {integrity: sha512-UM/AU/zxRh7crAnbhtiEitWuQggQhPp0DkHM8gOYy6/7zWQLinZHnZT8PbaxSWrv1SrYuqPI5lAjykKPvcLRkg==}
+  '@paraspell/sdk@6.2.2':
+    resolution: {integrity: sha512-4DWMJqXfr8UMK4wm8hRMVTH4sSI65MvnMy84qI9HtgEaPF90Qvdz7602m90DOcYI2vWac1dLNdPNMK9wqd38OQ==}
     peerDependencies:
       '@polkadot/api': '>= 12.4 < 13'
       '@polkadot/api-base': '>= 12.4 < 13'
@@ -14248,7 +14248,7 @@ snapshots:
     dependencies:
       '@open-web3/orml-type-definitions': 2.0.1
 
-  '@paraspell/sdk@6.2.1(@polkadot/api-base@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/api@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/apps-config@0.145.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@5.0.10))(@polkadot/types@14.0.1)(@polkadot/util@13.1.1)(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)':
+  '@paraspell/sdk@6.2.2(@polkadot/api-base@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/api@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/apps-config@0.145.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@5.0.10))(@polkadot/types@14.0.1)(@polkadot/util@13.1.1)(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@polkadot/api': 14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@polkadot/api-base': 14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^2.4.8
         version: 2.4.8(@types/react@18.3.9)(framer-motion@11.9.0(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@20.16.9)(typescript@5.6.2)))
       '@paraspell/sdk':
-        specifier: ^6.2.2
-        version: 6.2.2(@polkadot/api-base@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/api@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/apps-config@0.145.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@5.0.10))(@polkadot/types@14.0.1)(@polkadot/util@13.1.1)(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
+        specifier: ^6.2.3
+        version: 6.2.3(@polkadot/api-base@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/api@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/apps-config@0.145.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@5.0.10))(@polkadot/types@14.0.1)(@polkadot/util@13.1.1)(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
       '@polkadot-api/descriptors':
         specifier: file:.papi/descriptors
         version: file:.papi/descriptors(polkadot-api@1.3.3(bufferutil@4.0.8)(jiti@2.0.0)(postcss@8.4.47)(rxjs@7.8.1)(smoldot@2.0.22(bufferutil@4.0.8)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)(yaml@2.5.1))
@@ -2441,8 +2441,8 @@ packages:
   '@parallel-finance/type-definitions@2.0.1':
     resolution: {integrity: sha512-fC1QfhFFd8oSZqdIh6kmoMNvTxZdQGw1sTAbdYSINyVxyCxKiDg47ZP9bAZFDexL7POqnXnn4pYM7kUAnsT+8Q==}
 
-  '@paraspell/sdk@6.2.2':
-    resolution: {integrity: sha512-4DWMJqXfr8UMK4wm8hRMVTH4sSI65MvnMy84qI9HtgEaPF90Qvdz7602m90DOcYI2vWac1dLNdPNMK9wqd38OQ==}
+  '@paraspell/sdk@6.2.3':
+    resolution: {integrity: sha512-Q1XGeNVIQl3eBprk9DTugbCRiml7Oht3cFoRK1wzCJtfy0f+l9JfeJc9s1AkiIq56IUVgHmV5ftCzNsY92jjYA==}
     peerDependencies:
       '@polkadot/api': '>= 12.4 < 13'
       '@polkadot/api-base': '>= 12.4 < 13'
@@ -14248,7 +14248,7 @@ snapshots:
     dependencies:
       '@open-web3/orml-type-definitions': 2.0.1
 
-  '@paraspell/sdk@6.2.2(@polkadot/api-base@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/api@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/apps-config@0.145.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@5.0.10))(@polkadot/types@14.0.1)(@polkadot/util@13.1.1)(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)':
+  '@paraspell/sdk@6.2.3(@polkadot/api-base@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/api@14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/apps-config@0.145.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@8.7.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@5.0.10))(@polkadot/types@14.0.1)(@polkadot/util@13.1.1)(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@polkadot/api': 14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@polkadot/api-base': 14.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)

--- a/app/src/__tests__/Transfer.test.tsx
+++ b/app/src/__tests__/Transfer.test.tsx
@@ -1,10 +1,9 @@
-import { Direction, resolveDirection } from '@/services/transfer'
-import '@testing-library/jest-dom'
-import { Mainnet, mainnetRegistry, Testnet } from '../config/registry'
-import { convertAmount, safeConvertAmount, toHuman } from '@/utils/transfer'
-import { Enum } from 'polkadot-api'
-import { getTokenPrice } from '@/services/balance'
 import { getDestChainId } from '@/models/chain'
+import { getTokenPrice } from '@/services/balance'
+import { Direction, resolveDirection } from '@/services/transfer'
+import { convertAmount, safeConvertAmount, toHuman } from '@/utils/transfer'
+import '@testing-library/jest-dom'
+import { Mainnet, Testnet } from '../config/registry'
 
 describe('Transfer', () => {
   it('direction ToEthereum', () => {

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -117,7 +117,12 @@ const Transfer: FC = () => {
   const durationEstimate = direction ? getDurationEstimate(direction) : undefined
 
   const isTransferAllowed =
-    isValid && !isValidating && fees && transferStatus === 'Idle' && !requiresErc20SpendApproval
+    isValid &&
+    !isValidating &&
+    fees &&
+    transferStatus === 'Idle' &&
+    !requiresErc20SpendApproval &&
+    !loadingFees
 
   return (
     <form

--- a/app/src/config/registry.ts
+++ b/app/src/config/registry.ts
@@ -337,12 +337,13 @@ export interface Route {
 }
 
 export const mainnetRegistry: Registry = {
-  chains: [Mainnet.Ethereum, Mainnet.AssetHub, Mainnet.Bifrost, Mainnet.Mythos],
+  chains: [Mainnet.Ethereum, Mainnet.AssetHub, Mainnet.RelayChain, Mainnet.Bifrost, Mainnet.Mythos],
   tokens: [
     Mainnet.WETH,
     Mainnet.WBTC,
     Mainnet.USDC,
     Mainnet.USDT,
+    Mainnet.DOT,
     Mainnet.DAI,
     Mainnet.MYTH,
     Mainnet.WSTETH,
@@ -400,6 +401,18 @@ export const mainnetRegistry: Registry = {
         Mainnet.PEPE.id,
       ],
     },
+    {
+      from: Mainnet.RelayChain.uid,
+      to: Mainnet.AssetHub.uid,
+      sdk: 'ParaSpellApi',
+      tokens: [Mainnet.DOT.id],
+    },
+    {
+      from: Mainnet.AssetHub.uid,
+      to: Mainnet.RelayChain.uid,
+      sdk: 'ParaSpellApi',
+      tokens: [Mainnet.DOT.id],
+    },
     // {
     //   from: Mainnet.Bifrost.uid,
     //   to: Mainnet.AssetHub.uid,
@@ -445,6 +458,8 @@ export function getNativeToken(chain: Chain): Token {
       return Testnet.ROC
     case 'sepolia':
       return Testnet.ETH
+    case 'polkadot':
+      return Mainnet.DOT
     case 'polkadot-assethub':
       return Mainnet.DOT
     case 'ethereum':

--- a/app/src/config/registry.ts
+++ b/app/src/config/registry.ts
@@ -26,6 +26,18 @@ export namespace Mainnet {
       'wss://api-asset-hub-polkadot.dwellir.com',
   }
 
+  export const RelayChain: Chain = {
+    uid: 'polkadot',
+    name: 'Polkadot Relay Chain',
+    logoURI: 'https://s2.coinmarketcap.com/static/img/coins/64x64/6636.png',
+    chainId: 0,
+    network: Network.Polkadot,
+    supportedAddressTypes: ['ss58'],
+    specName: 'polkadot',
+    rpcConnection:
+      process.env.NEXT_PUBLIC_POLKADOT_RELAY_CHAIN_API_URL || 'wss://api-polkadot.dwellir.com',
+  }
+
   export const Bifrost: Chain = {
     uid: 'bifrost',
     name: 'Bifrost',

--- a/app/src/hooks/useFees.tsx
+++ b/app/src/hooks/useFees.tsx
@@ -6,9 +6,14 @@ import { Token } from '@/models/token'
 import { Fees } from '@/models/transfer'
 import { getTokenPrice } from '@/services/balance'
 import { Direction, resolveDirection } from '@/services/transfer'
-import { getRelayNode, getTokenSymbol } from '@/utils/paraspell'
+import { getTokenSymbol } from '@/utils/paraspell'
 import { toHuman } from '@/utils/transfer'
-import { assets, getTransferInfo, TNodeDotKsmWithRelayChains } from '@paraspell/sdk'
+import {
+  assets,
+  determineRelayChain,
+  getTransferInfo,
+  TNodeDotKsmWithRelayChains,
+} from '@paraspell/sdk'
 import { captureException } from '@sentry/nextjs'
 import { toEthereum, toPolkadot } from '@snowbridge/api'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -74,12 +79,14 @@ const useFees = (
         case Direction.WithinPolkadot: {
           const sourceChainNode =
             sourceChain.chainId === 0
-              ? getRelayNode(env) // relay chain
+              ? determineRelayChain(
+                  assets.getTNode(destinationChain.chainId) as TNodeDotKsmWithRelayChains,
+                ) // relay chain
               : (assets.getTNode(sourceChain.chainId) as TNodeDotKsmWithRelayChains) // parachain
 
           const destinationChainNode =
             destinationChain.chainId === 0
-              ? getRelayNode(env) // relay chain
+              ? determineRelayChain(sourceChainNode) // relay chain
               : (assets.getTNode(destinationChain.chainId) as TNodeDotKsmWithRelayChains) // parachain
 
           const tokenSymbol = getTokenSymbol(sourceChainNode, token)

--- a/app/src/hooks/useFees.tsx
+++ b/app/src/hooks/useFees.tsx
@@ -80,7 +80,7 @@ const useFees = (
             {
               symbol: tokenSymbol,
             },
-            amount,
+            amount.toString(),
             senderAddress,
           )
           fees = info.xcmFee.toString()

--- a/app/src/hooks/useFees.tsx
+++ b/app/src/hooks/useFees.tsx
@@ -8,7 +8,7 @@ import { getTokenPrice } from '@/services/balance'
 import { Direction, resolveDirection } from '@/services/transfer'
 import { getChainNode, getTokenSymbol } from '@/utils/paraspell'
 import { toHuman } from '@/utils/transfer'
-import { getTransferInfo } from '@paraspell/sdk'
+import { getOriginFeeDetails } from '@paraspell/sdk'
 import { captureException } from '@sentry/nextjs'
 import { toEthereum, toPolkadot } from '@snowbridge/api'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -74,16 +74,16 @@ const useFees = (
           const destinationChainNode = getChainNode(destinationChain, sourceChain)
           const tokenSymbol = getTokenSymbol(sourceChainNode, token)
 
-          // TODO: Try replace getTransferInfo with getOriginFeeDetails once available. Should be faster.
-          const info = await getTransferInfo(
+          const info = await getOriginFeeDetails(
             sourceChainNode,
             destinationChainNode,
+            {
+              symbol: tokenSymbol,
+            },
+            amount,
             senderAddress,
-            recipient,
-            { symbol: tokenSymbol },
-            amount.toString(),
           )
-          fees = info.originFeeBalance.xcmFee.xcmFee.toString()
+          fees = info.xcmFee.toString()
 
           const tokenCoingeckoId = nativeToken.coingeckoId ?? nativeToken.symbol
           tokenUSDValue = (await getTokenPrice(tokenCoingeckoId))?.usd ?? 0

--- a/app/src/hooks/useParaspellApi.tsx
+++ b/app/src/hooks/useParaspellApi.tsx
@@ -36,7 +36,6 @@ const useParaspellApi = () => {
 
     try {
       const tx = await createTx(params)
-      console.log(await tx.paymentInfo)
       await tx.signAndSend(
         account.address,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/src/hooks/useParaspellApi.tsx
+++ b/app/src/hooks/useParaspellApi.tsx
@@ -5,13 +5,13 @@ import { Environment } from '@/store/environmentStore'
 import { Account as SubstrateAccount } from '@/store/substrateWalletStore'
 import { getSenderAddress } from '@/utils/address'
 import { trackTransferMetrics } from '@/utils/analytics'
+import { createTx } from '@/utils/paraspell'
+import { handleSubmittableEvents } from '@/utils/polkadot'
 import { txWasCancelled } from '@/utils/transfer'
 import { captureException } from '@sentry/nextjs'
 import useNotification from './useNotification'
 import useOngoingTransfers from './useOngoingTransfers'
 import { Status, TransferParams } from './useTransfer'
-import { createTx } from '@/utils/paraspell'
-import { handleSubmittableEvents } from '@/utils/polkadot'
 
 const useParaspellApi = () => {
   const { addTransfer: addTransferToStorage } = useOngoingTransfers()
@@ -36,6 +36,7 @@ const useParaspellApi = () => {
 
     try {
       const tx = await createTx(params)
+      console.log(await tx.paymentInfo)
       await tx.signAndSend(
         account.address,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -63,7 +63,8 @@ const useTransferForm = () => {
     sourceWallet?.sender?.address,
     sourceChain,
     destinationChain,
-    tokenAmount,
+    tokenAmount?.token,
+    safeConvertAmount(tokenAmount?.amount, tokenAmount?.token),
     getRecipientAddress(manualRecipient, destinationWallet),
   )
 

--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -1,5 +1,5 @@
-import useEnvironment from '@/hooks/useEnvironment'
 import useBalance from '@/hooks/useBalance'
+import useEnvironment from '@/hooks/useEnvironment'
 import useTransfer from '@/hooks/useTransfer'
 import useWallet from '@/hooks/useWallet'
 import { Chain } from '@/models/chain'
@@ -60,6 +60,7 @@ const useTransferForm = () => {
   const destinationWallet = useWallet(destinationChain?.supportedAddressTypes.at(0))
   const { api } = usePapi(sourceChain)
   const { fees, loading: loadingFees } = useFees(
+    sourceWallet?.sender?.address,
     sourceChain,
     destinationChain,
     tokenAmount,

--- a/app/src/utils/paraspell.ts
+++ b/app/src/utils/paraspell.ts
@@ -71,8 +71,8 @@ export const getTokenSymbol = (sourceChain: TNodeWithRelayChains, token: Token) 
 /**
  * Helper function to determine the correct chain node
  *
- * @param chain chain to determine the node for
- * @param parachainToDetermineRelay parachain to determine the correct relay chain. If not provided, chain node defaults to polkadot if it is a relay chain.
+ * @param chain - chain to determine the node for
+ * @param parachainToDetermineRelay - parachain to determine the correct relay chain. If not provided, chain node defaults to polkadot if it is a relay chain.
  * @returns the Paraspell chain node
  */
 export const getChainNode = (

--- a/app/src/utils/paraspell.ts
+++ b/app/src/utils/paraspell.ts
@@ -1,6 +1,14 @@
 import { TransferParams } from '@/hooks/useTransfer'
+import { Chain } from '@/models/chain'
 import { Token } from '@/models/token'
-import { assets, Builder, Extrinsic, TNodeWithRelayChains } from '@paraspell/sdk'
+import {
+  assets,
+  Builder,
+  determineRelayChain,
+  Extrinsic,
+  TNodeDotKsmWithRelayChains,
+  TNodeWithRelayChains,
+} from '@paraspell/sdk'
 import { getApiPromise } from './polkadot'
 
 /**
@@ -58,4 +66,26 @@ export const getTokenSymbol = (sourceChain: TNodeWithRelayChains, token: Token) 
   if (!tokenSymbol) throw new Error('Transfer failed: Token symbol not supported.')
 
   return tokenSymbol
+}
+
+/**
+ * Helper function to determine the correct chain node
+ *
+ * @param chain chain to determine the node for
+ * @param parachainToDetermineRelay parachain to determine the correct relay chain. If not provided, chain node defaults to polkadot if it is a relay chain.
+ * @returns the Paraspell chain node
+ */
+export const getChainNode = (
+  chain: Chain,
+  parachainToDetermineRelay?: Chain,
+): TNodeDotKsmWithRelayChains => {
+  // relay chain
+  if (chain.chainId === 0)
+    return parachainToDetermineRelay
+      ? determineRelayChain(
+          assets.getTNode(parachainToDetermineRelay.chainId) as TNodeDotKsmWithRelayChains,
+        )
+      : 'Polkadot'
+
+  return assets.getTNode(chain.chainId) as TNodeDotKsmWithRelayChains // parachain
 }

--- a/app/src/utils/paraspell.ts
+++ b/app/src/utils/paraspell.ts
@@ -1,6 +1,5 @@
 import { TransferParams } from '@/hooks/useTransfer'
 import { Token } from '@/models/token'
-import { Environment } from '@/store/environmentStore'
 import { assets, Builder, Extrinsic, TNodeWithRelayChains } from '@paraspell/sdk'
 import { getApiPromise } from './polkadot'
 
@@ -59,14 +58,4 @@ export const getTokenSymbol = (sourceChain: TNodeWithRelayChains, token: Token) 
   if (!tokenSymbol) throw new Error('Transfer failed: Token symbol not supported.')
 
   return tokenSymbol
-}
-
-export const getRelayNode = (env: Environment): 'Polkadot' => {
-  switch (env) {
-    case Environment.Mainnet:
-      return 'Polkadot'
-
-    case Environment.Testnet:
-      return 'Polkadot' // TODO: change to Paseo once supported.
-  }
 }

--- a/app/src/utils/paraspell.ts
+++ b/app/src/utils/paraspell.ts
@@ -1,5 +1,6 @@
 import { TransferParams } from '@/hooks/useTransfer'
 import { Token } from '@/models/token'
+import { Environment } from '@/store/environmentStore'
 import { assets, Builder, Extrinsic, TNodeWithRelayChains } from '@paraspell/sdk'
 import { getApiPromise } from './polkadot'
 
@@ -58,4 +59,14 @@ export const getTokenSymbol = (sourceChain: TNodeWithRelayChains, token: Token) 
   if (!tokenSymbol) throw new Error('Transfer failed: Token symbol not supported.')
 
   return tokenSymbol
+}
+
+export const getRelayNode = (env: Environment): 'Polkadot' => {
+  switch (env) {
+    case Environment.Mainnet:
+      return 'Polkadot'
+
+    case Environment.Testnet:
+      return 'Polkadot' // TODO: change to Paseo once supported.
+  }
 }

--- a/app/src/utils/paraspell.ts
+++ b/app/src/utils/paraspell.ts
@@ -51,7 +51,7 @@ export const createTx = async (
   }
 }
 
-const getTokenSymbol = (sourceChain: TNodeWithRelayChains, token: Token) => {
+export const getTokenSymbol = (sourceChain: TNodeWithRelayChains, token: Token) => {
   // TODO(victor): write some tests
   const supportedAssets = assets.getAllAssetsSymbols(sourceChain)
   const tokenSymbol = supportedAssets.find(a => a.toLowerCase() === token.symbol.toLowerCase())

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -8,9 +8,9 @@ import { Environment } from '@/store/environmentStore'
 import { ethers, JsonRpcSigner } from 'ethers'
 
 /**
- * Safe version of `convertAmount` that handles `null` params
+ * Safe version of `convertAmount` that handles `null` and `undefined` params
  */
-export const safeConvertAmount = (input: number | null, token: Token | null): bigint | null => {
+export const safeConvertAmount = (input?: number | null, token?: Token | null): bigint | null => {
   if (input == null || !token) return null
 
   return BigInt(input * 10 ** token.decimals)

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -13,7 +13,7 @@ import { ethers, JsonRpcSigner } from 'ethers'
 export const safeConvertAmount = (input?: number | null, token?: Token | null): bigint | null => {
   if (input == null || !token) return null
 
-  return BigInt(input * 10 ** token.decimals)
+  return BigInt(Math.floor(input * 10 ** token.decimals))
 }
 
 /**


### PR DESCRIPTION
This PR
- adds Paraspell xcm fee fetching
- adds debounce to fetching fees.
- adds DOT transfers from AH to relay and back
- refactors useFees a bit

Future improvements:
- possibly replace `getTransferInfo` with `getOriginFeeDetails` when available. Could be faster