### PR TITLE
pre-commit: Add lint changes to commit

### DIFF
--- a/app/.husky/pre-commit
+++ b/app/.husky/pre-commit
@@ -1,6 +1,0 @@
-cd "$(dirname -- "$0")/.."
-
-pnpm run format
-pnpm run lint
-
-git add .

--- a/app/.husky/pre-commit
+++ b/app/.husky/pre-commit
@@ -2,3 +2,5 @@ cd "$(dirname -- "$0")/.."
 
 pnpm run format
 pnpm run lint
+
+git add .


### PR DESCRIPTION
I personally find it quite annoying to have the pre-commit linting but not including the side effects in the commit itself.

We can either:
-  add them to the commit as I'm doing it, with the downside that we might be adding other untracked changes that might not be desired as part of the commit
- drop this pre-commit all together
- any other ideas?


I know that Rudolfs also doesn't quite enjoy the way this flows now so I am not alone on this one 😜 