### PR TITLE
Improvement: get token price

### DIFF
--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -124,6 +124,14 @@ const Transfer: FC = () => {
     !requiresErc20SpendApproval &&
     !loadingFees
 
+  const shouldDisplayTxSummary =
+    isValid &&
+    tokenAmount &&
+    tokenAmount.token &&
+    !!tokenAmount.amount &&
+    !allowanceLoading &&
+    !requiresErc20SpendApproval
+
   return (
     <form
       onSubmit={handleSubmit}
@@ -317,19 +325,14 @@ const Transfer: FC = () => {
         )}
       </AnimatePresence>
 
-      {tokenAmount &&
-        tokenAmount.token &&
-        !!tokenAmount.amount &&
-        !allowanceLoading &&
-        !requiresErc20SpendApproval && (
-          <TxSummary
-            hidden={!isValid || requiresErc20SpendApproval}
-            loading={loadingFees || !fees}
-            tokenAmount={tokenAmount}
-            fees={fees}
-            durationEstimate={durationEstimate}
-          />
-        )}
+      {shouldDisplayTxSummary && (
+        <TxSummary
+          loading={loadingFees || !fees}
+          tokenAmount={tokenAmount}
+          fees={fees}
+          durationEstimate={durationEstimate}
+        />
+      )}
 
       {/* Transfer Button */}
       <Button

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -61,6 +61,7 @@ const Transfer: FC = () => {
 
   const {
     allowance: erc20SpendAllowance,
+    loading: allowanceLoading,
     approveAllowance,
     approving: isApprovingErc20Spend,
   } = useErc20Allowance({
@@ -316,15 +317,19 @@ const Transfer: FC = () => {
         )}
       </AnimatePresence>
 
-      {tokenAmount && tokenAmount.token && !!tokenAmount.amount && !requiresErc20SpendApproval && (
-        <TxSummary
-          hidden={!isValid || requiresErc20SpendApproval}
-          loading={loadingFees || !fees}
-          tokenAmount={tokenAmount}
-          fees={fees}
-          durationEstimate={durationEstimate}
-        />
-      )}
+      {tokenAmount &&
+        tokenAmount.token &&
+        !!tokenAmount.amount &&
+        !allowanceLoading &&
+        !requiresErc20SpendApproval && (
+          <TxSummary
+            hidden={!isValid || requiresErc20SpendApproval}
+            loading={loadingFees || !fees}
+            tokenAmount={tokenAmount}
+            fees={fees}
+            durationEstimate={durationEstimate}
+          />
+        )}
 
       {/* Transfer Button */}
       <Button

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -35,7 +35,7 @@ const TxSummary: FC<TxSummaryProps> = ({ loading, tokenAmount, fees, durationEst
         </div>
       )
     }
-    console.log("test commit")
+    console.log('test commit')
 
     return (
       <div className="tx-summary p-4 pt-3">

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -35,6 +35,7 @@ const TxSummary: FC<TxSummaryProps> = ({ loading, tokenAmount, fees, durationEst
         </div>
       )
     }
+    console.log("test commit")
 
     return (
       <div className="tx-summary p-4 pt-3">

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -16,17 +16,10 @@ interface TxSummaryProps {
   loading?: boolean
   fees?: AmountInfo | null
   durationEstimate?: string
-  hidden?: boolean
 }
 
-const TxSummary: FC<TxSummaryProps> = ({
-  loading,
-  tokenAmount,
-  fees,
-  durationEstimate,
-  hidden,
-}) => {
-  const { price, loading: isTokenPriceLoading } = useTokenPrice(tokenAmount.token)
+const TxSummary: FC<TxSummaryProps> = ({ loading, tokenAmount, fees, durationEstimate }) => {
+  const { price, loading: isLoadingTokenPrice } = useTokenPrice(tokenAmount.token)
   const transferAmount = toAmountInfo(tokenAmount, price)
   if (!fees) return null
 
@@ -75,7 +68,7 @@ const TxSummary: FC<TxSummaryProps> = ({
                     {formatAmount(Number(tokenAmount.amount))} {tokenAmount.token?.symbol}
                   </div>
                   <div className="min-h-6">
-                    {isTokenPriceLoading ? (
+                    {isLoadingTokenPrice ? (
                       <Skeleton className="h-6 w-20 rounded-md bg-turtle-level1" />
                     ) : (
                       transferAmount &&
@@ -117,19 +110,17 @@ const TxSummary: FC<TxSummaryProps> = ({
 
   return (
     <AnimatePresence>
-      {!hidden && (
-        <motion.div
-          initial={{ opacity: 0, height: 0 }}
-          animate={{
-            opacity: 1,
-            height: 'auto',
-            transition: { type: 'spring', bounce: 0.6, duration: 0.5 },
-          }}
-          exit={{ opacity: 0, height: 0, transition: { duration: 0.2 } }}
-        >
-          {renderContent()}
-        </motion.div>
-      )}
+      <motion.div
+        initial={{ opacity: 0, height: 0 }}
+        animate={{
+          opacity: 1,
+          height: 'auto',
+          transition: { type: 'spring', bounce: 0.6, duration: 0.5 },
+        }}
+        exit={{ opacity: 0, height: 0, transition: { duration: 0.2 } }}
+      >
+        {renderContent()}
+      </motion.div>
     </AnimatePresence>
   )
 }

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -35,7 +35,6 @@ const TxSummary: FC<TxSummaryProps> = ({ loading, tokenAmount, fees, durationEst
         </div>
       )
     }
-    console.log('test commit')
 
     return (
       <div className="tx-summary p-4 pt-3">

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -26,7 +26,7 @@ const TxSummary: FC<TxSummaryProps> = ({
   durationEstimate,
   hidden,
 }) => {
-  const { price, isTokenPriceLoading } = useTokenPrice(tokenAmount.token)
+  const { price, loading: isTokenPriceLoading } = useTokenPrice(tokenAmount.token)
   const transferAmount = toAmountInfo(tokenAmount, price)
   if (!fees) return null
 

--- a/app/src/hooks/useParaspellApi.tsx
+++ b/app/src/hooks/useParaspellApi.tsx
@@ -1,6 +1,6 @@
 import { NotificationSeverity } from '@/models/notification'
 import { StoredTransfer } from '@/models/transfer'
-import { getTokenPrice } from '@/services/balance'
+import { getCachedTokenPrice } from '@/services/balance'
 import { Environment } from '@/store/environmentStore'
 import { Account as SubstrateAccount } from '@/store/substrateWalletStore'
 import { getSenderAddress } from '@/utils/address'
@@ -44,7 +44,7 @@ const useParaspellApi = () => {
 
             // Get the current token price
             const senderAddress = await getSenderAddress(sender)
-            const tokenUSDValue = (await getTokenPrice(token.coingeckoId ?? token.symbol))?.usd ?? 0
+            const tokenUSDValue = (await getCachedTokenPrice(token))?.usd ?? 0
             const date = new Date()
 
             addTransferToStorage({

--- a/app/src/hooks/useSnowbridgeApi.tsx
+++ b/app/src/hooks/useSnowbridgeApi.tsx
@@ -1,8 +1,8 @@
 import { Chain } from '@/models/chain'
 import { NotificationSeverity } from '@/models/notification'
-import { getCoingekoId, Token } from '@/models/token'
+import { Token } from '@/models/token'
 import { StoredTransfer } from '@/models/transfer'
-import { getTokenPrice } from '@/services/balance'
+import { getCachedTokenPrice } from '@/services/balance'
 import { Direction, resolveDirection } from '@/services/transfer'
 import { Environment } from '@/store/environmentStore'
 import { getSenderAddress } from '@/utils/address'
@@ -157,14 +157,10 @@ const useSnowbridgeApi = () => {
         message: 'Transfer initiated. See below!',
         severity: NotificationSeverity.Success,
       })
-      const coingekoId = getCoingekoId(token)
-      const tokenUSDValue = (await getTokenPrice(coingekoId))?.usd
 
-      if (tokenUSDValue === null || tokenUSDValue === 0)
-        throw new Error('Failed to fetch token price')
-
-      const date = new Date()
       const senderAddress = await getSenderAddress(sender)
+      const tokenUSDValue = (await getCachedTokenPrice(token))?.usd ?? 0
+      const date = new Date()
 
       addTransferToStorage({
         id: sendResult.success!.messageId ?? 'todo', // TODO(nuno): what's a good fallback?

--- a/app/src/hooks/useTokenPrice.tsx
+++ b/app/src/hooks/useTokenPrice.tsx
@@ -5,13 +5,13 @@ import { useQuery } from '@tanstack/react-query'
 
 type TokenPriceResult = {
   price?: number
-  isTokenPriceLoading: boolean
+  loading: boolean
 }
 
 const useTokenPrice = (token?: Token | null): TokenPriceResult => {
   const {
     data: price,
-    isLoading: isTokenPriceLoading,
+    isLoading,
     error: isTokenPriceError,
   } = useQuery({
     queryKey: ['tokenPrice', token?.id],
@@ -25,10 +25,10 @@ const useTokenPrice = (token?: Token | null): TokenPriceResult => {
   if (isTokenPriceError) {
     console.error('useTokenPrice: Failed to fetch with error:', isTokenPriceError.message)
     captureException(isTokenPriceError.message)
-    return { price: undefined, isTokenPriceLoading: false }
+    return { price: undefined, loading: false }
   }
 
-  return { price: price?.usd, isTokenPriceLoading }
+  return { price: price?.usd, loading: isLoading }
 }
 
 export default useTokenPrice

--- a/app/src/registry/mainnet.ts
+++ b/app/src/registry/mainnet.ts
@@ -468,6 +468,7 @@ export const REGISTRY: Registry = {
   ],
   tokens: [
     Eth.WETH,
+    Eth.ETH,
     Eth.WBTC,
     Eth.USDC,
     Polkadot.USDC,

--- a/app/src/registry/mainnet.ts
+++ b/app/src/registry/mainnet.ts
@@ -468,7 +468,6 @@ export const REGISTRY: Registry = {
   ],
   tokens: [
     Eth.WETH,
-    Eth.ETH,
     Eth.WBTC,
     Eth.USDC,
     Polkadot.USDC,

--- a/app/src/registry/mainnet.ts
+++ b/app/src/registry/mainnet.ts
@@ -676,12 +676,6 @@ export const REGISTRY: Registry = {
       tokens: [Polkadot.DOT.id],
     },
     {
-      from: Centrifuge.uid,
-      to: Hydration.uid,
-      sdk: 'ParaSpellApi',
-      tokens: [Polkadot.CFG.id],
-    },
-    {
       from: Interlay.uid,
       to: RelayChain.uid,
       sdk: 'ParaSpellApi',


### PR DESCRIPTION
Implement cached token price fetch in: 

- useFees
- useSnowbridgeApi
- useParaspellApi

And support allowanceLoading checks before displaying the TxSummy component to avoid overlaps. 

Every call to goingecko API is now cached globally. 