### PR TITLE
Improve `formatAmount` and apply it on amount input

### DIFF
--- a/app/src/components/OngoingTransferDialog.tsx
+++ b/app/src/components/OngoingTransferDialog.tsx
@@ -136,7 +136,7 @@ export const OngoingTransferDialog = ({
               <div className="items-right flex flex-col space-x-1">
                 <div className="text-right">
                   <div className="text-lg">
-                    {formatAmount(toHuman(transfer.amount, transfer.token), 'Longer')}{' '}
+                    {formatAmount(toHuman(transfer.amount, transfer.token), 'Long')}{' '}
                     {transfer.token.symbol}
                   </div>
                   {typeof transfer.tokenUSDValue == 'number' && (
@@ -144,7 +144,7 @@ export const OngoingTransferDialog = ({
                       $
                       {formatAmount(
                         toHuman(transfer.amount, transfer.token) * (transfer.tokenUSDValue ?? 0),
-                        'Longer',
+                        'Long',
                       )}
                     </div>
                   )}
@@ -157,12 +157,12 @@ export const OngoingTransferDialog = ({
               <div className="font-bold">Fees</div>
               <div className="items-right flex flex-col space-x-1 text-right">
                 <div className="text-lg">
-                  {formatAmount(toHuman(transfer.fees.amount, transfer.fees.token), 'Longer')}{' '}
+                  {formatAmount(toHuman(transfer.fees.amount, transfer.fees.token), 'Long')}{' '}
                   {transfer.fees.token.symbol}
                 </div>
                 {typeof transfer.tokenUSDValue == 'number' && (
                   <div className="text-turtle-level4">
-                    ${formatAmount(transfer.fees.inDollars, 'Longer')}
+                    ${formatAmount(transfer.fees.inDollars, 'Long')}
                   </div>
                 )}
               </div>

--- a/app/src/components/TokenAmountSelect.tsx
+++ b/app/src/components/TokenAmountSelect.tsx
@@ -13,6 +13,7 @@ import { TokenLogo } from './TokenLogo'
 import { Chain } from '@/models/chain'
 import NumberFlow from '@number-flow/react'
 import useTokenPrice from '@/hooks/useTokenPrice'
+import { formatAmount } from '@/utils/transfer'
 
 export interface TokenAmountSelectProps extends SelectProps<TokenAmount> {
   sourceChain: Chain | null
@@ -115,7 +116,7 @@ const TokenAmountSelect = forwardRef<HTMLDivElement, TokenAmountSelectProps>(
                     error && 'text-turtle-error',
                   )}
                   placeholder={secondPlaceholder ?? 'Amount'}
-                  value={value?.amount ?? ''}
+                  value={value?.amount ? formatAmount(value.amount, 'Longer') : ''}
                   onChange={handleAmountChange}
                   onClick={e => e.stopPropagation()}
                   onWheel={e => e.target instanceof HTMLElement && e.target.blur()}

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -9,7 +9,7 @@ import {
   getAllowedSourceChains,
   getAllowedTokens,
 } from '@/utils/routes'
-import { getDurationEstimate } from '@/utils/transfer'
+import { formatAmount, getDurationEstimate } from '@/utils/transfer'
 import { Signer } from 'ethers'
 import { AnimatePresence, motion } from 'framer-motion'
 import Image from 'next/image'
@@ -111,8 +111,7 @@ const Transfer: FC = () => {
   else if (!sourceWallet || !tokenAmount?.token || !sourceWallet.isConnected || !isBalanceAvailable)
     amountPlaceholder = 'Amount'
   else if (balanceData?.value === 0n) amountPlaceholder = 'No balance'
-  else
-    amountPlaceholder = `${Number(balanceData?.formatted).toFixed(3).toString() + ' ' + tokenAmount?.token?.symbol}`
+  else amountPlaceholder = formatAmount(Number(balanceData?.formatted), 'Longer')
 
   const direction =
     sourceChain && destinationChain ? resolveDirection(sourceChain, destinationChain) : undefined

--- a/app/src/components/completed/TransactionDialog.tsx
+++ b/app/src/components/completed/TransactionDialog.tsx
@@ -176,15 +176,12 @@ export const TransactionDialog = ({ tx }: { tx: CompletedTransfer }) => {
               <div className="items-right flex flex-col space-x-1">
                 <div className="text-right">
                   <div className="text-lg">
-                    {formatAmount(toHuman(tx.amount, tx.token), 'Longer')} {tx.token.symbol}
+                    {formatAmount(toHuman(tx.amount, tx.token), 'Long')} {tx.token.symbol}
                   </div>
                   {typeof tx.tokenUSDValue == 'number' && (
                     <div className="text-turtle-level4">
                       $
-                      {formatAmount(
-                        toHuman(tx.amount, tx.token) * (tx.tokenUSDValue ?? 0),
-                        'Longer',
-                      )}
+                      {formatAmount(toHuman(tx.amount, tx.token) * (tx.tokenUSDValue ?? 0), 'Long')}
                     </div>
                   )}
                 </div>
@@ -196,12 +193,12 @@ export const TransactionDialog = ({ tx }: { tx: CompletedTransfer }) => {
               <div className="font-bold">Fees</div>
               <div className="items-right flex flex-col space-x-1 text-right">
                 <div>
-                  {formatAmount(toHuman(tx.fees.amount, tx.fees.token), 'Longer')}{' '}
+                  {formatAmount(toHuman(tx.fees.amount, tx.fees.token), 'Long')}{' '}
                   {tx.fees.token.symbol}
                 </div>
                 {typeof tx.tokenUSDValue == 'number' && (
                   <div className="text-turtle-level4">
-                    ${formatAmount(tx.fees.inDollars, 'Longer')}
+                    ${formatAmount(tx.fees.inDollars, 'Long')}
                   </div>
                 )}
               </div>

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -47,26 +47,37 @@ export function feeToHuman(fees: AmountInfo): string {
   return toHuman(fees.amount, fees.token).toFixed(10)
 }
 
-export type FormatLength = 'Shorter' | 'Longer'
+export type FormatLength = 'Short' | 'Long' | 'Longer'
+
+function getMaxSignificantDigits(length: FormatLength): number {
+  switch (length) {
+    case 'Short':
+      return 2
+    case 'Long':
+      return 6
+    case 'Longer':
+      return 10
+  }
+}
 
 /**
  * Formats a numerical amount into a human-readable, compact string representation.
  * @param amount - The amount to be formatted. For example, `1234567`.
- * @param length - Determines how many fraction digits will be shown, making it 'Shorter' or 'Longer'.
+ * @param length - Determines how many significant fraction digits will be shown for amount < 1.
  * @returns The amount formatted as a human-readable string. For example, `"1.23M"`.
  */
-export const formatAmount = (amount: number, length: FormatLength = 'Shorter'): string => {
+export const formatAmount = (amount: number, length: FormatLength = 'Short'): string => {
   if (amount < 1) {
     return new Intl.NumberFormat('en-US', {
-      maximumSignificantDigits: length === 'Shorter' ? 3 : 6,
-      maximumFractionDigits: 6,
+      maximumSignificantDigits: getMaxSignificantDigits(length),
+      roundingMode: 'floor',
     }).format(amount)
   } else {
     return new Intl.NumberFormat('en-US', {
       notation: 'compact',
       compactDisplay: 'short',
+      roundingMode: 'floor',
       maximumFractionDigits: 3,
-      maximumSignificantDigits: length === 'Shorter' ? 4 : 6,
     }).format(amount)
   }
 }


### PR DESCRIPTION
## Changes

- Improve `formatAmount` settings for better results 
  - Fix maximum/minimum fraction & significant digits settings
  - Set rounding to `floor` to not show values above the real amounts
- apply `formatAmount` on the `TokenAmountSelect` input value **


### Before
When applying the `Max` button, sometimes the value was extremely long and overflows the available space:
<img width="529" alt="Screenshot 2024-11-29 at 21 49 02" src="https://github.com/user-attachments/assets/28d685e8-abd1-41ef-b684-2901f76640d1">


### After
<img width="523" alt="Screenshot 2024-11-29 at 21 48 43" src="https://github.com/user-attachments/assets/0b1b2ae0-037d-456c-85d6-754bbd450523">


