### PR TITLE
Improve fees loading

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -222,6 +222,10 @@
   animation: slide-up-slight 150ms ease-in-out forwards;
 }
 
+.animate-slide-up-soft {
+  animation: slide-up-slight 350ms ease-in-out forwards;
+}
+
 .animate-height {
   transition: height 1s ease-in-out;
 }

--- a/app/src/components/Delayed.tsx
+++ b/app/src/components/Delayed.tsx
@@ -10,15 +10,14 @@ interface DelayProps {
 const Delayed: React.FC<DelayProps> = ({ millis, children }) => {
   const [shouldShow, setShouldShow] = useState<boolean>(false)
 
-  // Show when it reaches the delay timeout
+  // Should show when the delay timeout is reached
   useEffect(() => {
-    setTimeout(() => {
-      setShouldShow(true)
-    }, millis)
-  }, [millis, children])
+    const timer = setTimeout(() => setShouldShow(true), millis)
+    return () => clearTimeout(timer)
+  }, [millis])
 
   // Render
-  return shouldShow ? children : <></>
+  return shouldShow ? children : null
 }
 
 export default Delayed

--- a/app/src/components/Delayed.tsx
+++ b/app/src/components/Delayed.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react'
+
+interface DelayProps {
+  /** The delay period in milliseconds */
+  millis: number
+  /** Children component(s) */
+  children?: React.ReactNode
+}
+
+const Delayed: React.FC<DelayProps> = ({ millis, children }) => {
+  const [shouldShow, setShouldShow] = useState<boolean>(false)
+
+  // Show when it reaches the delay timeout
+  useEffect(() => {
+    setTimeout(() => {
+      setShouldShow(true)
+    }, millis)
+  }, [millis, children])
+
+  // Render
+  return shouldShow ? children : <></>
+}
+
+export default Delayed

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -328,7 +328,7 @@ const Transfer: FC = () => {
 
       {shouldDisplayTxSummary && (
         <TxSummary
-          loading={loadingFees}
+          loading={loadingFees || tokenAmount.amount == 5}
           tokenAmount={tokenAmount}
           fees={fees}
           durationEstimate={durationEstimate}

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -328,7 +328,7 @@ const Transfer: FC = () => {
 
       {shouldDisplayTxSummary && (
         <TxSummary
-          loading={loadingFees || tokenAmount.amount == 5}
+          loading={loadingFees}
           tokenAmount={tokenAmount}
           fees={fees}
           durationEstimate={durationEstimate}

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -2,7 +2,7 @@ import { AmountInfo } from '@/models/transfer'
 import { formatAmount, toAmountInfo, toHuman } from '@/utils/transfer'
 import { AnimatePresence, motion } from 'framer-motion'
 import NumberFlow from '@number-flow/react'
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { spinnerSize } from './Button'
 import LoadingIcon from './svg/LoadingIcon'
 import { ExclamationMark } from './svg/ExclamationMark'
@@ -29,17 +29,38 @@ const TxSummary: FC<TxSummaryProps> = ({
 }) => {
   const { price } = useTokenPrice(tokenAmount.token)
   const transferAmount = toAmountInfo(tokenAmount, price)
+  const [isTakingTooLong, setIsTakingTooLong] = useState<boolean>(false)
+
+  // Determine is it's loading fees for too long
+  useEffect(() => {
+    if (!loading) {
+      setIsTakingTooLong(false)
+      return
+    }
+
+    setTimeout(() => {
+      setIsTakingTooLong(true)
+    }, 6000) // 6s
+  }, [loading])
+
   if (!fees && !loading) return null
 
   const renderContent = () => {
     if (loading || !fees) {
       return (
-        <div className="mt-4 flex h-[10rem] w-full items-center justify-center rounded-[8px] bg-turtle-level1">
+        <div className="mt-4 flex h-[10rem] w-full flex-col items-center justify-center rounded-[8px] bg-turtle-level1">
           <LoadingIcon
             className="animate-spin"
             width={spinnerSize['lg']}
             height={spinnerSize['lg']}
+            color={colors['turtle-secondary']}
           />
+          <div className="mt-2 text-turtle-secondary">Loading fees...</div>
+          {isTakingTooLong && (
+            <div className="animate-slide-up mt-1 text-xs text-turtle-level6">
+              Sorry that it&apos;s taking so long. Hang on or try again
+            </div>
+          )}
         </div>
       )
     }

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -2,7 +2,7 @@ import { AmountInfo } from '@/models/transfer'
 import { formatAmount, toAmountInfo, toHuman } from '@/utils/transfer'
 import { AnimatePresence, motion } from 'framer-motion'
 import NumberFlow from '@number-flow/react'
-import { FC, useEffect, useState } from 'react'
+import { FC } from 'react'
 import { spinnerSize } from './Button'
 import LoadingIcon from './svg/LoadingIcon'
 import { ExclamationMark } from './svg/ExclamationMark'
@@ -11,6 +11,7 @@ import { AMOUNT_VS_FEE_RATIO } from '@/config'
 import { TokenAmount } from '@/models/select'
 import useTokenPrice from '@/hooks/useTokenPrice'
 import { cn } from '@/utils/cn'
+import Delayed from './Delayed'
 
 interface TxSummaryProps {
   tokenAmount: TokenAmount
@@ -29,19 +30,6 @@ const TxSummary: FC<TxSummaryProps> = ({
 }) => {
   const { price } = useTokenPrice(tokenAmount.token)
   const transferAmount = toAmountInfo(tokenAmount, price)
-  const [isTakingTooLong, setIsTakingTooLong] = useState<boolean>(false)
-
-  // Determine is it's loading fees for too long
-  useEffect(() => {
-    if (!loading) {
-      setIsTakingTooLong(false)
-      return
-    }
-
-    setTimeout(() => {
-      setIsTakingTooLong(true)
-    }, 6000) // 6s
-  }, [loading])
 
   if (!fees && !loading) return null
 
@@ -56,11 +44,11 @@ const TxSummary: FC<TxSummaryProps> = ({
             color={colors['turtle-secondary']}
           />
           <div className="mt-2 text-turtle-secondary">Loading fees...</div>
-          {isTakingTooLong && (
-            <div className="animate-slide-up mt-1 text-xs text-turtle-level6">
+          <Delayed millis={6000}>
+            <div className="animate-slide-up-soft mt-1 text-xs text-turtle-level6">
               Sorry that it&apos;s taking so long. Hang on or try again
             </div>
-          )}
+          </Delayed>
         </div>
       )
     }

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -36,16 +36,18 @@ const TxSummary: FC<TxSummaryProps> = ({
   const renderContent = () => {
     if (loading || !fees) {
       return (
-        <div className="mt-4 flex h-[10rem] w-full flex-col items-center justify-center rounded-[8px] bg-turtle-level1">
+        <div className="mt-4 flex h-[10rem] w-full animate-pulse flex-col items-center justify-center rounded-[8px] bg-turtle-level1">
           <LoadingIcon
             className="animate-spin"
             width={spinnerSize['lg']}
             height={spinnerSize['lg']}
             color={colors['turtle-secondary']}
           />
-          <div className="mt-2 text-turtle-secondary">Loading fees...</div>
-          <Delayed millis={6000}>
-            <div className="animate-slide-up-soft mt-1 text-xs text-turtle-level6">
+          <div className="animate-slide-up-soft mt-2 text-sm font-bold text-turtle-secondary">
+            Loading fees
+          </div>
+          <Delayed millis={7000}>
+            <div className="animate-slide-up-soft mt-1 text-xs text-turtle-secondary">
               Sorry that it&apos;s taking so long. Hang on or try again
             </div>
           </Delayed>


### PR DESCRIPTION
Improve the fees loading UI and UX:

- Add mini header "Loading fees" - otherwise users have no idea what they are waiting for
- Add a little emphatic and help tagline if it's taking too long

Eventually we want to redesign this but this feel - to me - like a small quick improvement for v2.

### Preview
(This demo was tweaked so that the fees kept loading if the amount == 5) 

https://github.com/user-attachments/assets/e7e9839c-dd33-4cac-b9c1-de1f2de767f4

