### PR TITLE
Make Transfer button click-area bigger

### DIFF
--- a/site/src/components/header.tsx
+++ b/site/src/components/header.tsx
@@ -12,17 +12,17 @@ export default function Header() {
         </div>
       </Link>
 
-      <nav>
-        <ul className="items-center space-x-6">
-          <li>
-            <button className="btn btn-primary flex h-[20px] w-[122px] flex-row justify-center rounded-lg border-black text-lg font-medium hover:border-black sm:h-[56px] sm:text-xl">
-              <a href="https://app.turtle.cool" target="_blank">
+      <a href="https://app.turtle.cool" target="_blank">
+        <nav>
+          <ul className="items-center space-x-6">
+            <li>
+              <div className="btn btn-primary flex h-[20px] w-[122px] flex-row justify-center rounded-lg border-black text-lg font-medium hover:border-black sm:h-[56px] sm:text-xl">
                 Transfer
-              </a>
-            </button>
-          </li>
-        </ul>
-      </nav>
+              </div>
+            </li>
+          </ul>
+        </nav>
+      </a>
     </header>
   )
 }


### PR DESCRIPTION
So that clicking anywhere on the button triggers navigation to the website.

I bumped into this a couple times and thought the button was broken. Also removed the `<button>` tag, because we can't nest a button within an `<a>` anchor tag if we want it to be valid HTML5.

Problem:

https://github.com/user-attachments/assets/d0e7c6eb-04e1-4d5a-83d8-0c6a83f5eb92

After the fix:

https://github.com/user-attachments/assets/46c65632-4008-4af4-8355-e7c859a0b8a8

