### PR TITLE
fix: Track transactions only on production

### DIFF
--- a/app/src/hooks/useSnowbridgeApi.tsx
+++ b/app/src/hooks/useSnowbridgeApi.tsx
@@ -8,6 +8,7 @@ import { Environment } from '@/store/environmentStore'
 import { getSenderAddress } from '@/utils/address'
 import { trackTransferMetrics } from '@/utils/analytics'
 import { txWasCancelled } from '@/utils/transfer'
+import { isProduction } from '@/utils/env'
 import { captureException } from '@sentry/nextjs'
 import { Context, toEthereum, toPolkadot } from '@snowbridge/api'
 import { WalletOrKeypair } from '@snowbridge/api/dist/toEthereum'
@@ -181,7 +182,7 @@ const useSnowbridgeApi = () => {
         fees,
       } satisfies StoredTransfer)
 
-      if (environment === Environment.Mainnet) {
+      if (environment === Environment.Mainnet && isProduction) {
         trackTransferMetrics({
           id: sendResult.success?.messageId,
           sender: senderAddress,

--- a/app/src/utils/env.ts
+++ b/app/src/utils/env.ts
@@ -1,5 +1,6 @@
 export const isDevelopment: boolean = process.env.NODE_ENV === 'development'
 export const isPreview: boolean = process.env.VERCEL_ENV === 'preview'
+export const isProduction: boolean = process.env.VERCEL_ENV === 'production'
 export const projectId: string | undefined = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
 export const vercelDomain: string | undefined = process.env.NEXT_PUBLIC_VERCEL_URL
 


### PR DESCRIPTION
We don't want txs from devs testing locally to end up in the stats.
For reference: https://vercel.com/docs/projects/environment-variables/system-environment-variables#VERCEL_ENV.