### PR TITLE
fix: Show correct ethereum account identicon

### DIFF
--- a/app/src/components/Account.tsx
+++ b/app/src/components/Account.tsx
@@ -1,20 +1,20 @@
-import Identicon from '@polkadot/react-identicon'
-
 import useLookupName from '@/hooks/useLookupName'
-import { Network } from '@/models/chain'
+import { AddressType, Network } from '@/models/chain'
 import { truncateAddress } from '@/utils/address'
 import { cn } from '@/utils/cn'
-
+import Identicon from '@polkadot/react-identicon'
 import CopyAddress from './ClipboardCopy'
 
 function Account({
   network,
+  addressType,
   address,
   className,
   allowCopy = true,
   size = 14,
 }: {
   network: Network
+  addressType?: AddressType
   address: string
   className?: string
   allowCopy?: boolean
@@ -23,9 +23,12 @@ function Account({
   const accountName = useLookupName(network, address)
   const accountDisplay = accountName ? accountName : truncateAddress(address, 4, 4)
 
+  console.log(addressType)
+
   return (
     <div className="flex items-center gap-x-1">
-      {network === 'Polkadot' ? (
+      {/* Account Icon Substrate */}
+      {addressType === 'ss58' && (
         <Identicon
           value={address}
           size={size}
@@ -35,14 +38,27 @@ function Account({
             className,
           )}
         />
-      ) : (
+      )}
+
+      {/* Account Icon EVM */}
+      {addressType === 'evm' && (
         <div
           className={cn(
-            'mr-1 h-4 w-4 rounded-full border border-turtle-secondary-dark bg-gradient-to-r from-violet-400 to-purple-300 hover:cursor-default',
+            'mr-1 flex items-start overflow-hidden rounded-full border border-turtle-secondary-dark hover:cursor-default',
             className,
           )}
-        />
+          style={{ width: size, height: size }}
+        >
+          <Identicon
+            value={address}
+            size={size}
+            theme="ethereum"
+            className="hover:cursor-default"
+          />
+        </div>
       )}
+
+      {/* Copy Address  */}
       {allowCopy ? (
         <CopyAddress content={accountDisplay} address={address} />
       ) : (

--- a/app/src/components/OngoingTransfer.tsx
+++ b/app/src/components/OngoingTransfer.tsx
@@ -1,14 +1,14 @@
-import { FC } from 'react'
-import Image from 'next/image'
 import { StoredTransfer } from '@/models/transfer'
 import { Direction } from '@/services/transfer'
 import { formatOngoingTransferDate } from '@/utils/datetime'
 import { formatAmount, toHuman } from '@/utils/transfer'
+import Image from 'next/image'
+import { FC } from 'react'
+import { colors } from '../../tailwind.config'
 import Account from './Account'
 import { ArrowRight } from './svg/ArrowRight'
-import TransferEstimate from './TransferEstimate'
 import LoadingIcon from './svg/LoadingIcon'
-import { colors } from '../../tailwind.config'
+import TransferEstimate from './TransferEstimate'
 
 const OngoingTransfer: FC<{
   direction: Direction
@@ -60,12 +60,14 @@ const OngoingTransfer: FC<{
       <div className="flex items-center">
         <Account
           network={transfer.sourceChain.network}
+          addressType={transfer.sourceChain.supportedAddressTypes.at(0)}
           address={transfer.sender}
           allowCopy={false}
         />
         <ArrowRight className="mx-3 h-[0.8rem] w-[0.8rem]" fill={colors['turtle-secondary-dark']} />
         <Account
           network={transfer.destChain.network}
+          addressType={transfer.destChain.supportedAddressTypes.at(0)}
           address={transfer.recipient}
           allowCopy={false}
         />

--- a/app/src/components/OngoingTransferDialog.tsx
+++ b/app/src/components/OngoingTransferDialog.tsx
@@ -8,6 +8,7 @@ import Account from './Account'
 import OngoingTransfer from './OngoingTransfer'
 import { ArrowRight } from './svg/ArrowRight'
 import { ArrowUpRight } from './svg/ArrowUpRight'
+import { TokenLogo } from './TokenLogo'
 import TransferEstimate from './TransferEstimate'
 import {
   Dialog,
@@ -17,7 +18,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from './ui/dialog'
-import { TokenLogo } from './TokenLogo'
 
 export const OngoingTransferDialog = ({
   transfer,
@@ -114,7 +114,12 @@ export const OngoingTransferDialog = ({
               Sender
             </div>
             <div className="p-4 text-sm">
-              <Account network={transfer.sourceChain.network} address={transfer.sender} size={24} />
+              <Account
+                network={transfer.sourceChain.network}
+                addressType={transfer.sourceChain.supportedAddressTypes.at(0)}
+                address={transfer.sender}
+                size={24}
+              />
             </div>
             <div className="relative border-t p-4 text-sm">
               <div className="absolute -top-2 left-2.5 bg-white px-0.5 text-xs text-turtle-level5">
@@ -122,6 +127,7 @@ export const OngoingTransferDialog = ({
               </div>
               <Account
                 network={transfer.destChain.network}
+                addressType={transfer.destChain.supportedAddressTypes.at(0)}
                 address={transfer.recipient}
                 size={24}
               />

--- a/app/src/components/completed/TransactionCard.tsx
+++ b/app/src/components/completed/TransactionCard.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 
-import { TxStatus, CompletedTransfer, TransferResult } from '@/models/transfer'
+import { CompletedTransfer, TransferResult, TxStatus } from '@/models/transfer'
 import { cn } from '@/utils/cn'
 import { formatHours } from '@/utils/datetime'
 import { formatAmount, toHuman } from '@/utils/transfer'
@@ -96,6 +96,7 @@ export const TransactionCard = ({ tx }: { tx: CompletedTransfer }) => {
         >
           <Account
             network={tx.sourceChain.network}
+            addressType={tx.sourceChain.supportedAddressTypes.at(0)}
             address={tx.sender}
             className={transferSucceeded ? 'border-black' : 'border-turtle-error-dark'}
             allowCopy={false}
@@ -108,6 +109,7 @@ export const TransactionCard = ({ tx }: { tx: CompletedTransfer }) => {
           />
           <Account
             network={tx.destChain.network}
+            addressType={tx.destChain.supportedAddressTypes.at(0)}
             address={tx.recipient}
             className={transferSucceeded ? 'border-black' : 'border-turtle-error-dark'}
             allowCopy={false}

--- a/app/src/components/completed/TransactionDialog.tsx
+++ b/app/src/components/completed/TransactionDialog.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 
-import { TxStatus, CompletedTransfer } from '@/models/transfer'
+import { CompletedTransfer, TxStatus } from '@/models/transfer'
 import { cn } from '@/utils/cn'
 import { formatCompletedTransferDate, formatHours } from '@/utils/datetime'
 import { formatAmount, toHuman } from '@/utils/transfer'
@@ -149,6 +149,7 @@ export const TransactionDialog = ({ tx }: { tx: CompletedTransfer }) => {
             <div className="p-4 text-sm">
               <Account
                 network={tx.sourceChain.network}
+                addressType={tx.sourceChain.supportedAddressTypes.at(0)}
                 address={tx.sender}
                 size={24}
                 className={transferSucceeded ? 'border-black' : 'border-turtle-error-dark'}
@@ -161,6 +162,7 @@ export const TransactionDialog = ({ tx }: { tx: CompletedTransfer }) => {
               </div>
               <Account
                 network={tx.destChain.network}
+                addressType={tx.destChain.supportedAddressTypes.at(0)}
                 address={tx.recipient}
                 size={24}
                 className={transferSucceeded ? 'border-black' : 'border-turtle-error-dark'}

--- a/app/src/registry/mainnet.ts
+++ b/app/src/registry/mainnet.ts
@@ -80,7 +80,7 @@ export const Moonbeam: Chain = {
   chainId: 2004,
   destinationFeeDOT: '500000000',
   network: 'Polkadot',
-  supportedAddressTypes: ['ss58'],
+  supportedAddressTypes: ['evm'],
   walletType: 'SubstrateEVM',
   rpcConnection: `wss://api-moonbeam.dwellir.com/${DWELLIR_KEY}`,
 }


### PR DESCRIPTION
This PR fixes an issue that evm addresses are just a purple circle and not the actual account logo (see below). And it fixes moonbeam's wrong `addressType`.



<img width="363" alt="image" src="https://github.com/user-attachments/assets/d6b4658b-16ae-4aab-b4e5-5d3423cce652">



Before it was like this:
<img width="317" alt="image" src="https://github.com/user-attachments/assets/610ebd58-9114-460d-b5fc-5ee44e0743e1">
