### PR TITLE
fix: Prevent fetching fees with an invalid manual address

### DIFF
--- a/app/src/components/ChainSelect.tsx
+++ b/app/src/components/ChainSelect.tsx
@@ -123,12 +123,17 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
                 />
               )}
               {!manualRecipient?.enabled && !!value && accountName}
+
+              {/* Manual Recipient Address */}
               {manualRecipient && manualRecipient.enabled && (
                 <>
-                  <VerticalDivider className={!manualRecipient.address ? 'visible' : 'invisible'} />
+                  <VerticalDivider className={manualRecipient.address ? 'invisible' : 'visible'} />
                   <input
                     type="text"
-                    className="h-[70%] w-full bg-transparent focus:border-0 focus:outline-none"
+                    className={cn(
+                      'ml-1 h-[70%] w-full bg-transparent focus:border-0 focus:outline-none',
+                      error && 'text-turtle-error',
+                    )}
                     placeholder="Address"
                     autoFocus
                     value={manualRecipient.address}

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -262,7 +262,7 @@ const Transfer: FC = () => {
                 className="flex items-center gap-1 self-center pt-1"
               >
                 <AlertIcon />
-                <span className="text-xs">Double check address to avoid losing funds.</span>
+                <span className="text-xs">Double check the address to avoid losing funds</span>
               </motion.div>
             )}
           </AnimatePresence>

--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -68,7 +68,9 @@ const useTransferForm = () => {
     sourceChain,
     destinationChain,
     tokenAmount?.token,
-    getRecipientAddress(manualRecipient, destinationWallet),
+    manualRecipient.enabled && manualRecipientError != null
+      ? undefined
+      : getRecipientAddress(manualRecipient, destinationWallet),
   )
 
   const {

--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -68,9 +68,9 @@ const useTransferForm = () => {
     sourceChain,
     destinationChain,
     tokenAmount?.token,
-    manualRecipient.enabled && manualRecipientError != null
-      ? undefined
-      : getRecipientAddress(manualRecipient, destinationWallet),
+    isValidRecipient(manualRecipient, destinationChain)
+      ? getRecipientAddress(manualRecipient, destinationWallet)
+      : null,
   )
 
   const {
@@ -221,14 +221,9 @@ const useTransferForm = () => {
 
   // validate recipient address
   useEffect(() => {
-    const isValidAddress =
-      !manualRecipient.enabled ||
-      !destinationChain ||
-      isValidAddressType(manualRecipient.address, destinationChain.supportedAddressTypes) ||
-      manualRecipient.address === ''
-
-    if (isValidAddress) setManualRecipientError('')
-    else setManualRecipientError('Invalid Address')
+    setManualRecipientError(
+      isValidRecipient(manualRecipient, destinationChain) ? '' : 'Invalid Address',
+    )
   }, [manualRecipient.address, destinationChain, sourceChain, manualRecipient.enabled])
 
   // validate token amount
@@ -286,6 +281,15 @@ const useTransferForm = () => {
     balanceData,
     fetchBalance,
   }
+}
+
+function isValidRecipient(manualRecipient: ManualRecipient, destinationChain: Chain | null) {
+  return (
+    !manualRecipient.enabled ||
+    !destinationChain ||
+    isValidAddressType(manualRecipient.address, destinationChain.supportedAddressTypes) ||
+    manualRecipient.address === ''
+  )
 }
 
 export default useTransferForm

--- a/app/src/registry/mainnet.ts
+++ b/app/src/registry/mainnet.ts
@@ -18,7 +18,7 @@ export const Ethereum: Chain = {
 
 export const AssetHub: Chain = {
   uid: 'polkadot-assethub',
-  name: 'Polkadot Asset Hub',
+  name: 'Asset Hub',
   logoURI: '/logos/assethub.svg',
   chainId: 1000,
   network: 'Polkadot',
@@ -29,7 +29,7 @@ export const AssetHub: Chain = {
 
 export const RelayChain: Chain = {
   uid: 'polkadot',
-  name: 'Polkadot Relay Chain',
+  name: 'Polkadot',
   logoURI: '/logos/polkadot.svg',
   chainId: 0,
   network: 'Polkadot',
@@ -40,7 +40,7 @@ export const RelayChain: Chain = {
 
 export const BridgeHub: Chain = {
   uid: 'polkadot-bridgehub',
-  name: 'Polkadot Bridge Hub',
+  name: 'Bridge Hub',
   logoURI: '/logos/bridgehub.svg',
   chainId: 1002,
   network: 'Polkadot',

--- a/app/src/utils/address.ts
+++ b/app/src/utils/address.ts
@@ -80,10 +80,12 @@ export const isValidSubstrateAddress = (address: string): boolean => {
   }
 }
 
-/** Get the recipient address based on the enabled manual input and the connected destination wallet. */
+/**
+ * Get the recipient address based on the enabled manual input and the connected destination wallet.
+ * @remarks It doesn't check whether the address is valid or not
+ * */
 export const getRecipientAddress = (manualRecipient: ManualRecipient, wallet?: WalletInfo) => {
-  if (manualRecipient.enabled) return manualRecipient.address
-  return wallet?.sender?.address
+  return manualRecipient.enabled ? manualRecipient.address : wallet?.sender?.address
 }
 
 /** Get the transfer sender address from the sender origin base (Substrate or Ethereum)*/


### PR DESCRIPTION
Fixes https://linear.app/velocitylabs/issue/VEL-165/fix-error-when-trying-to-load-fees-with-an-invalid-dest-addr

When the dest address is set to manual and it's invalid, the app keeps trying to fetch fees the fees and it of course keeps failing and keeps piling up on error notifications:

<img width="1800" alt="Screenshot 2024-12-03 at 19 09 13" src="https://github.com/user-attachments/assets/c01e34d4-f81e-4923-90e0-1bbe3bf2bf67">

We also fix the design for the error state, making the input content reddish too.
