### PR TITLE
fix: scroll down on transfer initiation

### DIFF
--- a/app/src/components/OngoingTransfers.tsx
+++ b/app/src/components/OngoingTransfers.tsx
@@ -1,11 +1,11 @@
 'use client'
 
+import useOngoingTransfersTracker from '@/hooks/useOngoingTransfersTracker'
 import { DisplaysTransfers } from '@/models/transfer'
 import { useOngoingTransfersStore } from '@/store/ongoingTransfersStore'
-import OngoingTransferDialog from './OngoingTransferDialog'
-import useOngoingTransfersTracker from '@/hooks/useOngoingTransfersTracker'
-import { ArrowRight } from './svg/ArrowRight'
 import { colors } from '../../tailwind.config'
+import OngoingTransferDialog from './OngoingTransferDialog'
+import { ArrowRight } from './svg/ArrowRight'
 
 const OngoingTransfers = ({
   newTransferInit,
@@ -18,9 +18,9 @@ const OngoingTransfers = ({
   const { statusMessages } = useOngoingTransfersTracker()
 
   return (
-    <div>
+    <div id="ongoing-txs">
       {ongoingTransfers && ongoingTransfers.length > 0 && (
-        <div className="my-20" id="ongoing-txs">
+        <div className="my-20">
           <div className="xl-letter-spacing self-center text-center text-3xl text-turtle-foreground">
             Ongoing
           </div>

--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -214,7 +214,7 @@ const useTransferForm = () => {
             document
               .getElementById('ongoing-txs')
               ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-          }, 1000)
+          }, 500)
         },
       })
     },

--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -210,9 +210,11 @@ const useTransferForm = () => {
             severity: NotificationSeverity.Success,
           })
 
-          document
-            .getElementById('ongoing-txs')
-            ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+          setTimeout(() => {
+            document
+              .getElementById('ongoing-txs')
+              ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+          }, 1000)
         },
       })
     },


### PR DESCRIPTION
This PR fixes a bug where it wasn't scrolled down to ongoing transfers correctly.