### PR TITLE
fix: default account icon

### DIFF
--- a/app/src/components/Account.tsx
+++ b/app/src/components/Account.tsx
@@ -63,8 +63,8 @@ function Account({
             'mr-1 flex items-start overflow-hidden rounded-full border border-turtle-secondary-dark hover:cursor-default',
             className,
             network === 'Ethereum'
-              ? 'bg-gradient-to-l from-[#38bdf8] via-[#fb7185] to-[#84cc16]'
-              : 'bg-gradient-to-tr from-[#22c55e] via-[#0e7490] to-[#3b82f6]',
+              ? 'bg-gradient-to-tr from-green-400 to-blue-500'
+              : 'bg-gradient-to-tr from-indigo-500 to-pink-500',
           )}
           style={{ width: size, height: size }}
         />

--- a/app/src/components/Account.tsx
+++ b/app/src/components/Account.tsx
@@ -56,6 +56,20 @@ function Account({
         </div>
       )}
 
+      {/* Fallback Account Icon */}
+      {!addressType && (
+        <div
+          className={cn(
+            'mr-1 flex items-start overflow-hidden rounded-full border border-turtle-secondary-dark hover:cursor-default',
+            className,
+            network === 'Ethereum'
+              ? 'bg-gradient-to-l from-[#38bdf8] via-[#fb7185] to-[#84cc16]'
+              : 'bg-gradient-to-tr from-[#22c55e] via-[#0e7490] to-[#3b82f6]',
+          )}
+          style={{ width: size, height: size }}
+        />
+      )}
+
       {/* Copy Address  */}
       {allowCopy ? (
         <CopyAddress content={accountDisplay} address={address} />


### PR DESCRIPTION
add fallback account icon when no addressType is available: 

<img width="711" alt="image" src="https://github.com/user-attachments/assets/a11703b7-32f6-4e65-a62d-702b51b8ead3">


<img width="658" alt="image" src="https://github.com/user-attachments/assets/816e1895-5f82-4f3a-afdb-d70ce23c136d">

vs: 

<img width="602" alt="image" src="https://github.com/user-attachments/assets/c65aef24-9452-4538-8b07-7ccd595ce2e5">

(We can't stay without default icon or the list will be weird with some empty icons on some cards/modal)
@NunoAlexandre I let you tweak the gradients' colors if you do not like them :) 