### PR TITLE
feat: add duration tool tip for xcm transfers

### DIFF
--- a/app/src/components/Tooltip.tsx
+++ b/app/src/components/Tooltip.tsx
@@ -7,18 +7,26 @@ import React, { FC } from 'react'
 export interface TooltipProps {
   content: React.ReactNode
   children: React.ReactNode
+  className?: string
   showIcon?: boolean
+  showArrow?: boolean
 }
 
-export const Tooltip: FC<TooltipProps> = ({ children, content, showIcon = true }) => {
+export const Tooltip: FC<TooltipProps> = ({
+  children,
+  content,
+  className,
+  showIcon = true,
+  showArrow = true,
+}) => {
   if (!content) return <>{children}</>
   return (
     <NextTooltip
-      showArrow
+      showArrow={showArrow}
       delay={350}
       closeDelay={100}
       content={
-        <div className={cn('flex gap-1', showIcon ? 'pl-[4px] pr-[6px]' : 'px-[5px]')}>
+        <div className={cn('flex gap-1', showIcon ? 'pl-[4px] pr-[6px]' : 'px-[5px]', className)}>
           {showIcon && <Image src={TooltipIcon} alt="icon" className="mr-[2px]" />}
           {content}
         </div>

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -335,6 +335,7 @@ const Transfer: FC = () => {
           fees={fees}
           durationEstimate={durationEstimate}
           canPayFees={canPayFees}
+          direction={direction}
           className={cn({ 'opacity-30': transferStatus !== 'Idle' })}
         />
       )}

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -109,6 +109,8 @@ const TxSummary: FC<TxSummaryProps> = ({
                     content={
                       'Transfer should be done in ~30s but our service takes up to 2 minutes to catch up'
                     }
+                    className="max-w-xs text-center sm:max-w-sm"
+                    showArrow={false}
                   >
                     <Info className="h-3 w-3 text-turtle-level6" />
                   </Tooltip>

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -11,12 +11,16 @@ import { TokenAmount } from '@/models/select'
 import useTokenPrice from '@/hooks/useTokenPrice'
 import { cn } from '@/utils/cn'
 import Delayed from './Delayed'
+import { Direction } from '@/services/transfer'
+import { Tooltip } from './Tooltip'
+import { Info } from 'lucide-react'
 
 interface TxSummaryProps {
   tokenAmount: TokenAmount
   loading?: boolean
   fees?: AmountInfo | null
   durationEstimate?: string
+  direction?: Direction
   canPayFees: boolean
   className?: string
 }
@@ -26,6 +30,7 @@ const TxSummary: FC<TxSummaryProps> = ({
   tokenAmount,
   fees,
   durationEstimate,
+  direction,
   canPayFees,
   className,
 }) => {
@@ -96,8 +101,18 @@ const TxSummary: FC<TxSummaryProps> = ({
               <div className="flex">
                 <div className="font-bold">Duration</div>
               </div>
-              <div className="items-right flex">
+              <div className="items-right flex items-center space-x-0.5">
                 <div className="text-turtle-foreground">{durationEstimate}</div>
+                {direction === Direction.WithinPolkadot && (
+                  <Tooltip
+                    showIcon={false}
+                    content={
+                      'Transfer should be done in ~30s but our service takes up to 2 minutes to catch up'
+                    }
+                  >
+                    <Info className="h-3 w-3 text-turtle-level6" />
+                  </Tooltip>
+                )}
               </div>
             </li>
           </ul>

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -110,7 +110,6 @@ const TxSummary: FC<TxSummaryProps> = ({
                       'Your tokens should land in ~30s but our services usually take ~2 minutes to catch up'
                     }
                     className="max-w-xs text-center sm:max-w-sm"
-                    showArrow={false}
                   >
                     <Info className="h-3 w-3 text-turtle-foreground" />
                   </Tooltip>


### PR DESCRIPTION
Add duration tooltip for XCM transfers in the TxSummary component. 

![image](https://github.com/user-attachments/assets/a2fa6bf1-fb34-452d-9098-567606ae4ad7)
