### PR TITLE
improvement ⚡ show precise available balance

### DIFF
--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -115,7 +115,7 @@ const Transfer: FC = () => {
   else if (!sourceWallet || !tokenAmount?.token || !sourceWallet.isConnected || !isBalanceAvailable)
     amountPlaceholder = 'Amount'
   else if (balanceData?.value === 0n) amountPlaceholder = 'No balance'
-  else amountPlaceholder = formatAmount(Number(balanceData?.formatted) * 0.95, 'Longer') // TODO: remove *0.95 once paraspell supports ED.
+  else amountPlaceholder = formatAmount(Number(balanceData?.formatted), 'Longer')
 
   const direction =
     sourceChain && destinationChain ? resolveDirection(sourceChain, destinationChain) : undefined

--- a/app/src/hooks/useBalance.tsx
+++ b/app/src/hooks/useBalance.tsx
@@ -5,7 +5,7 @@ import { Erc20Balance } from '@/services/balance'
 import { Environment } from '@/store/environmentStore'
 import { getCurrencyId, getRelayNode } from '@/utils/paraspell'
 import { toHuman } from '@/utils/transfer'
-import { assets, getAssetBalance } from '@paraspell/sdk'
+import { assets, getTransferableAmount } from '@paraspell/sdk'
 import { captureException } from '@sentry/nextjs'
 import { useCallback, useEffect, useState } from 'react'
 import { useBalance as useBalanceWagmi } from 'wagmi'
@@ -67,7 +67,12 @@ const useBalance = ({ env, chain, token, address }: UseBalanceParams) => {
           const currency = getCurrencyId(env, node, chain.uid, token)
 
           const balance =
-            (await getAssetBalance({ address, node, currency, api: chain.rpcConnection })) ?? 0n
+            (await getTransferableAmount({
+              address,
+              node,
+              currency,
+              api: chain.rpcConnection,
+            })) ?? 0n
 
           fetchedBalance = {
             value: balance,

--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -169,7 +169,7 @@ const useTransferForm = () => {
       {
         token: tokenAmount.token,
         // Parse as number, then format to our display standard, then parse again as number
-        amount: Number(formatAmount(Number(balanceData.formatted) * 0.95, 'Longer')), // TODO: remove *0.95 once paraspell supports ED.
+        amount: Number(formatAmount(Number(balanceData.formatted), 'Longer')),
       },
       { shouldValidate: true },
     )


### PR DESCRIPTION
This PR replaces our 95% quick fix for showing balances with the correct amount that is now fetchable via Paraspell.