### PR TITLE
improvement ⚡ Add snowbridge fee warning

### DIFF
--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -1,19 +1,19 @@
+import { AMOUNT_VS_FEE_RATIO } from '@/config'
+import useTokenPrice from '@/hooks/useTokenPrice'
+import { TokenAmount } from '@/models/select'
 import { AmountInfo } from '@/models/transfer'
+import { Direction } from '@/services/transfer'
+import { cn } from '@/utils/cn'
 import { formatAmount, toAmountInfo, toHuman } from '@/utils/transfer'
 import { AnimatePresence, motion } from 'framer-motion'
-import { FC } from 'react'
-import { spinnerSize } from './Button'
-import LoadingIcon from './svg/LoadingIcon'
-import { ExclamationMark } from './svg/ExclamationMark'
-import { colors } from '../../tailwind.config'
-import { AMOUNT_VS_FEE_RATIO } from '@/config'
-import { TokenAmount } from '@/models/select'
-import useTokenPrice from '@/hooks/useTokenPrice'
-import { cn } from '@/utils/cn'
-import Delayed from './Delayed'
-import { Direction } from '@/services/transfer'
-import { Tooltip } from './Tooltip'
 import { Info } from 'lucide-react'
+import { FC } from 'react'
+import { colors } from '../../tailwind.config'
+import { spinnerSize } from './Button'
+import Delayed from './Delayed'
+import { ExclamationMark } from './svg/ExclamationMark'
+import LoadingIcon from './svg/LoadingIcon'
+import { Tooltip } from './Tooltip'
 
 interface TxSummaryProps {
   tokenAmount: TokenAmount
@@ -64,6 +64,8 @@ const TxSummary: FC<TxSummaryProps> = ({
     const isAmountTooLow =
       transferAmount && transferAmount.inDollars < fees.inDollars * AMOUNT_VS_FEE_RATIO
 
+    const showSnowbridgeFeeWarning = direction === Direction.ToPolkadot
+
     return (
       <div className={cn('tx-summary p-4 pt-0', className)}>
         <div className="pt-3">
@@ -71,7 +73,7 @@ const TxSummary: FC<TxSummaryProps> = ({
           <ul>
             <li className="mt-4 flex items-start justify-between border-turtle-level2">
               <div className="items-left flex flex-col">
-                <div className="font-bold">Fee</div>
+                <div className="font-bold">{showSnowbridgeFeeWarning ? 'Bridging Fee' : 'Fee'}</div>
                 {!canPayFees && (
                   <div className="ml-[-6px] mt-1 flex w-auto flex-row items-center rounded-[6px] border-1 border-black bg-turtle-warning px-2 py-1 text-xs">
                     <ExclamationMark
@@ -86,9 +88,21 @@ const TxSummary: FC<TxSummaryProps> = ({
               </div>
               <div className="items-right flex">
                 <div>
-                  <div className="text-right text-turtle-foreground">
+                  <div className="flex items-center text-right text-turtle-foreground">
                     {formatAmount(toHuman(fees.amount, fees.token))} {fees.token.symbol}
+                    {showSnowbridgeFeeWarning && (
+                      <Tooltip
+                        showIcon={false}
+                        content={
+                          'This excludes ETH gas fees. Check your wallet popup for the total amount.'
+                        }
+                        className="max-w-xs text-center sm:max-w-sm"
+                      >
+                        <Info className="ml-0.5 h-3 w-3 text-turtle-foreground" />
+                      </Tooltip>
+                    )}
                   </div>
+
                   {fees.inDollars > 0 && (
                     <div className="text-right text-turtle-level4">
                       ${formatAmount(fees.inDollars)}


### PR DESCRIPTION
This PR adds a warning that the snowbridge fees are only for its service and not eth gas costs.
Changed also the label Fee to Bridging Fee for such transfers.

<img width="361" alt="image" src="https://github.com/user-attachments/assets/32c3107c-e63c-4138-8902-efe197885531" />
