### PR TITLE
fix: unmask sentry replay

### DIFF
--- a/app/sentry.client.config.ts
+++ b/app/sentry.client.config.ts
@@ -27,14 +27,14 @@ Sentry.init({
   // in development and sample at a lower rate in production
   replaysSessionSampleRate: 0.1,
 
-  // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [
     // Add browser profiling integration to the list of integrations
     Sentry.browserProfilingIntegration(),
 
     Sentry.replayIntegration({
-      maskAllText: true,
-      blockAllMedia: true,
+      maskAllText: false,
+      blockAllMedia: false,
+      maskAllInputs: false,
     }),
 
     Sentry.feedbackIntegration({


### PR DESCRIPTION
This PR removes some unnecessary mask on sentry replay recordings.