### PR TITLE
fix: add coingeckoId to the TON token

### DIFF
--- a/app/src/registry/mainnet/tokens.ts
+++ b/app/src/registry/mainnet/tokens.ts
@@ -137,6 +137,7 @@ export namespace Eth {
     address: '0x582d872a1b094fc48f5de31d3b73f2d9be47def1',
     multilocation:
       '{"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"1"}}},{"AccountKey20":{"network":null,"key":"0x582d872a1b094fc48f5de31d3b73f2d9be47def1"}}]}}',
+    coingeckoId: 'the-open-network',
     origin: snowbridgeWrapped(),
   }
 


### PR DESCRIPTION
This fixs the fetch API error. [See issue](https://linear.app/velocitylabs/issue/VEL-221/fix-token-price-endpoint-500-error)