### PR TITLE
improvement: faster tx summary showing

### DIFF
--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -131,12 +131,7 @@ const Transfer: FC = () => {
     canPayFees
 
   const shouldDisplayTxSummary =
-    isValid &&
-    tokenAmount &&
-    tokenAmount.token &&
-    !!tokenAmount.amount &&
-    !allowanceLoading &&
-    !requiresErc20SpendApproval
+    tokenAmount?.token && !allowanceLoading && !requiresErc20SpendApproval
 
   return (
     <form

--- a/app/src/hooks/useFees.tsx
+++ b/app/src/hooks/useFees.tsx
@@ -7,7 +7,7 @@ import { getNativeToken } from '@/registry'
 import { Eth, Polkadot } from '@/registry/mainnet/tokens'
 import { getCachedTokenPrice } from '@/services/balance'
 import { Direction, resolveDirection } from '@/services/transfer'
-import { getExampleAddress } from '@/utils/address'
+import { getPlaceholderAddress } from '@/utils/address'
 import { getCurrencyId, getRelayNode } from '@/utils/paraspell'
 import { toHuman } from '@/utils/transfer'
 import { getOriginFeeDetails, getTNode } from '@paraspell/sdk'
@@ -18,11 +18,9 @@ import useEnvironment from './useEnvironment'
 import useSnowbridgeContext from './useSnowbridgeContext'
 
 const useFees = (
-  senderAddress?: string | null,
   sourceChain?: Chain | null,
   destinationChain?: Chain | null,
   token?: Token | null,
-  recipient?: string | null,
 ) => {
   const [fees, setFees] = useState<AmountInfo | null>(null)
   const [canPayFees, setCanPayFees] = useState<boolean>(true)
@@ -90,10 +88,9 @@ const useFees = (
             origin: sourceChainNode,
             destination: destinationChainNode,
             currency,
-            amount: BigInt(10 ** token.decimals).toString(), // hardcoded amount because the fee is usually independent of the amount
-            account: senderAddress ?? getExampleAddress(sourceChain.supportedAddressTypes[0]),
-            accountDestination:
-              recipient ?? getExampleAddress(destinationChain.supportedAddressTypes[0]),
+            amount: BigInt(10 ** token.decimals).toString(), // hardcode amount because the fee is usually independent of the amount
+            account: getPlaceholderAddress(sourceChain.supportedAddressTypes[0]), // hardcode sender address because the fee is usually independent of the sender
+            accountDestination: getPlaceholderAddress(destinationChain.supportedAddressTypes[0]), // hardcode recipient address because the fee is usually independent of the recipient
             api: sourceChain.rpcConnection,
           })
           tokenUSDValue = (await getCachedTokenPrice(nativeToken))?.usd ?? 0
@@ -124,16 +121,7 @@ const useFees = (
       setLoading(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    env,
-    sourceChain,
-    destinationChain,
-    token?.id,
-    recipient,
-    snowbridgeContext,
-    senderAddress,
-    addNotification,
-  ])
+  }, [env, sourceChain, destinationChain, token?.id, snowbridgeContext, addNotification])
 
   useEffect(() => {
     fetchFees()

--- a/app/src/hooks/useFees.tsx
+++ b/app/src/hooks/useFees.tsx
@@ -7,6 +7,7 @@ import { getNativeToken } from '@/registry'
 import { Eth, Polkadot } from '@/registry/mainnet/tokens'
 import { getCachedTokenPrice } from '@/services/balance'
 import { Direction, resolveDirection } from '@/services/transfer'
+import { getExampleAddress } from '@/utils/address'
 import { getCurrencyId, getRelayNode } from '@/utils/paraspell'
 import { toHuman } from '@/utils/transfer'
 import { getOriginFeeDetails, getTNode } from '@paraspell/sdk'
@@ -32,7 +33,7 @@ const useFees = (
   const env = useEnvironment()
 
   const fetchFees = useCallback(async () => {
-    if (!sourceChain || !destinationChain || !token || !recipient || !senderAddress) {
+    if (!sourceChain || !destinationChain || !token) {
       setFees(null)
       return
     }
@@ -90,8 +91,9 @@ const useFees = (
             destination: destinationChainNode,
             currency,
             amount: BigInt(10 ** token.decimals).toString(), // hardcoded amount because the fee is usually independent of the amount
-            account: senderAddress,
-            accountDestination: recipient,
+            account: senderAddress ?? getExampleAddress(sourceChain.supportedAddressTypes[0]),
+            accountDestination:
+              recipient ?? getExampleAddress(destinationChain.supportedAddressTypes[0]),
             api: sourceChain.rpcConnection,
           })
           tokenUSDValue = (await getCachedTokenPrice(nativeToken))?.usd ?? 0

--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -63,15 +63,7 @@ const useTransferForm = () => {
     fees,
     loading: loadingFees,
     canPayFees,
-  } = useFees(
-    sourceWallet?.sender?.address,
-    sourceChain,
-    destinationChain,
-    tokenAmount?.token,
-    isValidRecipient(manualRecipient, destinationChain)
-      ? getRecipientAddress(manualRecipient, destinationWallet)
-      : null,
-  )
+  } = useFees(sourceChain, destinationChain, tokenAmount?.token)
 
   const {
     balance: balanceData,

--- a/app/src/utils/address.ts
+++ b/app/src/utils/address.ts
@@ -91,3 +91,13 @@ export const getRecipientAddress = (manualRecipient: ManualRecipient, wallet?: W
 /** Get the transfer sender address from the sender origin base (Substrate or Ethereum)*/
 export const getSenderAddress = async (sender: Sender): Promise<string> =>
   sender instanceof JsonRpcSigner ? await sender.getAddress() : (sender as InjectedAccount).address
+
+/** Get an example address for a specific type. Can be used to prefetch the fees before address input, as fees shouldn't differ. */
+export const getExampleAddress = (type: AddressType): string => {
+  switch (type) {
+    case 'evm':
+      return '0xC1af060ab8213AD5EE2Dab1a5891245eBe756400' // Velocity Address
+    case 'ss58':
+      return '5EkE3p9hnUi5p14d7pJnDBjiNYqPNPSutKbyAuvV3mFGGxPi' // Velocity Address
+  }
+}

--- a/app/src/utils/address.ts
+++ b/app/src/utils/address.ts
@@ -92,8 +92,8 @@ export const getRecipientAddress = (manualRecipient: ManualRecipient, wallet?: W
 export const getSenderAddress = async (sender: Sender): Promise<string> =>
   sender instanceof JsonRpcSigner ? await sender.getAddress() : (sender as InjectedAccount).address
 
-/** Get an example address for a specific type. Can be used to prefetch the fees before address input, as fees shouldn't differ. */
-export const getExampleAddress = (type: AddressType): string => {
+/** Get a placeholder address for a specific type. Can be used to prefetch the fees before address input, as fees shouldn't differ. */
+export const getPlaceholderAddress = (type: AddressType): string => {
   switch (type) {
     case 'evm':
       return '0xC1af060ab8213AD5EE2Dab1a5891245eBe756400' // Velocity Address


### PR DESCRIPTION
This PR adds some tricks to show the txSummary faster. It uses fallback addresses to fetch fees if no addresses are inputed yet. After they are inputed it refetches the fees to be correct.

Closes VEL-197