### PR TITLE
fix: fix isPreview and isProduction util functions

### DIFF
--- a/app/src/utils/env.ts
+++ b/app/src/utils/env.ts
@@ -1,6 +1,6 @@
 export const isDevelopment: boolean = process.env.NODE_ENV === 'development'
-export const isPreview: boolean = process.env.VERCEL_ENV === 'preview'
-export const isProduction: boolean = process.env.VERCEL_ENV === 'production'
+export const isPreview: boolean = process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
+export const isProduction: boolean = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
 export const projectId: string | undefined = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
 export const vercelDomain: string | undefined = process.env.NEXT_PUBLIC_VERCEL_URL
 


### PR DESCRIPTION
When "Automatically expose System Environment Variables" is enabled in Vercel, all env variables have to be prefixed by `NEXT_PUBLIC_`. [Source](https://github.com/vercel/next.js/discussions/45802#discussioncomment-9022511).