### PR TITLE
feat: add xcm dry run api

### DIFF
--- a/app/src/hooks/useParaspellApi.tsx
+++ b/app/src/hooks/useParaspellApi.tsx
@@ -161,21 +161,19 @@ const useParaspellApi = () => {
     try {
       const result = await dryRun(params, params.sourceChain.rpcConnection)
 
-      const dryRunResult: DryRunResult = {
+      return {
         type: 'Supported',
         ...result,
       }
-
-      return dryRunResult
     } catch (e: unknown) {
       if (e instanceof Error && e.message.includes('DryRunApi is not available'))
-        return { type: 'Unsupported', success: false, failureReason: e.message } as DryRunResult
+        return { type: 'Unsupported', success: false, failureReason: e.message }
 
       return {
         type: 'Supported',
         success: false,
         failureReason: (e as Error).message,
-      } as DryRunResult
+      }
     }
   }
 

--- a/app/src/hooks/useParaspellApi.tsx
+++ b/app/src/hooks/useParaspellApi.tsx
@@ -153,8 +153,6 @@ const useParaspellApi = () => {
         captureException(new Error(`Dry run failed: ${dryRunResult.failureReason}`))
       }
 
-      console.log('Dry run result:', dryRunResult)
-
       return dryRunResult.success
     } catch (e) {
       // No dry run available, so we unfortunately must assume it's valid.

--- a/app/src/hooks/useParaspellApi.tsx
+++ b/app/src/hooks/useParaspellApi.tsx
@@ -164,14 +164,14 @@ const useParaspellApi = () => {
       }
 
       return dryRunResult.success
-    } catch (e) {
+    } catch (e: unknown) {
       // No dry run available, so we unfortunately must assume it's valid.
+      if (e instanceof Error && e.message.includes('DryRunApi is not available')) return true
+
+      // capture other type of errors but still unblock the transfer
+      captureException(e)
       return true
     }
-  }
-
-  function getTxId(event: TxEvent): string {
-    return event.txHash.toString()
   }
 
   const addToOngoingTransfers = async (

--- a/app/src/hooks/useParaspellApi.tsx
+++ b/app/src/hooks/useParaspellApi.tsx
@@ -7,9 +7,8 @@ import { getSenderAddress } from '@/utils/address'
 import { trackTransferMetrics } from '@/utils/analytics'
 import { isProduction } from '@/utils/env'
 import { handleObservableEvents } from '@/utils/papi'
-import { createTx, dryRun, moonbeamTransfer } from '@/utils/paraspell'
+import { createTx, dryRun, DryRunResult, moonbeamTransfer } from '@/utils/paraspell'
 import { txWasCancelled } from '@/utils/transfer'
-import { TDryRunResult } from '@paraspell/sdk'
 import { captureException } from '@sentry/nextjs'
 import { switchChain } from '@wagmi/core'
 import { InvalidTxError, TxEvent } from 'polkadot-api'
@@ -157,8 +156,6 @@ const useParaspellApi = () => {
       setStatus('Idle')
     }
   }
-
-  type DryRunResult = { type: 'Supported' | 'Unsupported' } & TDryRunResult
 
   const validate = async (params: TransferParams): Promise<DryRunResult> => {
     try {

--- a/app/src/hooks/useSnowbridgeApi.tsx
+++ b/app/src/hooks/useSnowbridgeApi.tsx
@@ -48,7 +48,6 @@ const useSnowbridgeApi = () => {
       onComplete,
     } = params
 
-    setStatus('Loading')
     try {
       if (snowbridgeContext === undefined) {
         addNotification({

--- a/app/src/utils/paraspell.ts
+++ b/app/src/utils/paraspell.ts
@@ -14,6 +14,8 @@ import {
 } from '@paraspell/sdk'
 import { captureException } from '@sentry/nextjs'
 
+export type DryRunResult = { type: 'Supported' | 'Unsupported' } & TDryRunResult
+
 /**
  * Creates a submittable PAPI transaction using Paraspell Builder.
  *

--- a/app/src/utils/paraspell.ts
+++ b/app/src/utils/paraspell.ts
@@ -62,15 +62,6 @@ export const moonbeamTransfer = async (
     throw new Error('Transfer failed: chain id not found.')
   const currencyId = getCurrencyId(environment, sourceChainFromId, sourceChain.uid, token)
 
-  console.log('Moonbeam transfer:', {
-    sourceChainFromId,
-    destinationChainFromId,
-    currencyId,
-    amount,
-    recipient,
-    viemClient,
-  })
-
   return EvmBuilder()
     .from('Moonbeam')
     .to(destinationChainFromId)

--- a/app/src/utils/paraspell.ts
+++ b/app/src/utils/paraspell.ts
@@ -7,6 +7,7 @@ import {
   getAllAssetsSymbols,
   getTNode,
   TCurrencyCore,
+  TDryRunResult,
   TNodeDotKsmWithRelayChains,
   type TPapiTransaction,
 } from '@paraspell/sdk'
@@ -39,6 +40,28 @@ export const createTx = async (
     .currency({ ...currencyId, amount })
     .address(recipient)
     .build()
+}
+
+export const dryRun = async (
+  params: TransferParams,
+  wssEndpoint?: string,
+): Promise<TDryRunResult> => {
+  const { environment, sourceChain, destinationChain, token, amount, recipient } = params
+
+  const relay = getRelayNode(environment)
+  const sourceChainFromId = getTNode(sourceChain.chainId, relay)
+  const destinationChainFromId = getTNode(destinationChain.chainId, relay)
+  if (!sourceChainFromId || !destinationChainFromId)
+    throw new Error('Dry Run failed: chain id not found.')
+
+  const currencyId = getCurrencyId(environment, sourceChainFromId, sourceChain.uid, token)
+
+  return await Builder(wssEndpoint)
+    .from(sourceChainFromId)
+    .to(destinationChainFromId)
+    .currency({ ...currencyId, amount })
+    .address(recipient)
+    .dryRun()
 }
 
 export const getTokenSymbol = (sourceChain: TNodeDotKsmWithRelayChains, token: Token) => {

--- a/app/src/utils/paraspell.ts
+++ b/app/src/utils/paraspell.ts
@@ -42,6 +42,14 @@ export const createTx = async (
     .build()
 }
 
+/**
+ * Dry run a transfer using Paraspell.
+ *
+ * @param params - The transfer parameters
+ * @param wssEndpoint - An optional wss chain endpoint to connect to a specific blockchain.
+ * @returns - A Promise that resolves a dry run result.
+ * @throws - An error if the dry run api is not available.
+ */
 export const dryRun = async (
   params: TransferParams,
   wssEndpoint?: string,


### PR DESCRIPTION
This PR
- adds automatic dry run when available for xcm transfers

Design Decisions
- If no dry run is available we treat it as if it has succeeded
- The dry run returns precise xcm fees. But we run the dry run after the form was filled out and immediately before the tx-sign popup appears. So I decided to not use those fees for now. Alternatively, we can explore running the dry run as part of fetching the fees in txSummary. I would prefer to do that in a seperate PR tho.