### PR TITLE
feat: reorder chains/tokens and add clear button

### DIFF
--- a/app/src/components/ChainSelect.tsx
+++ b/app/src/components/ChainSelect.tsx
@@ -181,7 +181,7 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
                     label="Clear"
                     size="sm"
                     variant="outline"
-                    className="max-w-[77px]"
+                    className="max-w-[77px] text-sm"
                     onClick={() => {
                       onChange(null)
                       setIsOpen(false)

--- a/app/src/components/ChainSelect.tsx
+++ b/app/src/components/ChainSelect.tsx
@@ -1,7 +1,5 @@
 'use client'
 import useLookupName from '@/hooks/useLookupName'
-import { useEnsAvatar } from 'wagmi'
-import { normalize } from 'viem/ens'
 import { useOutsideClick } from '@/hooks/useOutsideClick'
 import { Chain } from '@/models/chain'
 import { ManualRecipient, SelectProps } from '@/models/select'
@@ -10,6 +8,9 @@ import { cn } from '@/utils/cn'
 import Image from 'next/image'
 import { forwardRef, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
+import { normalize } from 'viem/ens'
+import { useEnsAvatar } from 'wagmi'
+import Button from './Button'
 import Dropdown from './Dropdown'
 import ChainIcon from './svg/ChainIcon'
 import ChevronDown from './svg/ChevronDown'
@@ -37,6 +38,7 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
       trailing,
       error,
       disabled,
+      clearable,
       className,
     },
     ref,
@@ -150,22 +152,38 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
 
         <Dropdown isOpen={isOpen} dropdownRef={dropdownRef}>
           {options.map(option => {
-            if (!option.allowed) return
+            if (!option.allowed) return null
+            const isSelected = value?.uid === option.uid
             return (
               <li
                 key={option.uid}
-                className="flex cursor-pointer items-center gap-1 px-3 py-3 hover:bg-turtle-level1"
+                className="flex cursor-pointer items-center justify-between px-3 py-3 hover:bg-turtle-level1"
                 onClick={() => handleSelectionChange(option)}
               >
-                <Image
-                  src={option.logoURI}
-                  alt={option.name}
-                  width={24}
-                  height={24}
-                  priority
-                  className="h-[2rem] w-[2rem] rounded-full border-1 border-turtle-foreground bg-background"
-                />
-                <span className="text-sm">{option.name}</span>
+                <div className="flex items-center gap-2">
+                  <Image
+                    src={option.logoURI}
+                    alt={option.name}
+                    width={24}
+                    height={24}
+                    priority
+                    className="h-[2rem] w-[2rem] rounded-full border-1 border-turtle-foreground bg-background"
+                  />
+                  <span className="text-sm">{option.name}</span>
+                </div>
+
+                {isSelected && clearable && (
+                  <Button
+                    label="clear"
+                    size="sm"
+                    variant="outline"
+                    className="ml-4 max-w-8"
+                    onClick={() => {
+                      onChange(null)
+                      setIsOpen(false)
+                    }}
+                  />
+                )}
               </li>
             )
           })}

--- a/app/src/components/ChainSelect.tsx
+++ b/app/src/components/ChainSelect.tsx
@@ -14,6 +14,7 @@ import Button from './Button'
 import Dropdown from './Dropdown'
 import ChainIcon from './svg/ChainIcon'
 import ChevronDown from './svg/ChevronDown'
+import { Cross } from './svg/Cross'
 import { Tooltip } from './Tooltip'
 import VerticalDivider from './VerticalDivider'
 
@@ -177,12 +178,17 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
                     label="Clear"
                     size="sm"
                     variant="outline"
-                    className="ml-4 max-w-[4.875rem]"
+                    className="max-w-[77px]"
                     onClick={() => {
                       onChange(null)
                       setIsOpen(false)
                     }}
-                  />
+                  >
+                    <div className="mr-1 flex items-center">
+                      <Cross stroke="black" />
+                      <span>Clear</span>
+                    </div>
+                  </Button>
                 )}
               </li>
             )

--- a/app/src/components/ChainSelect.tsx
+++ b/app/src/components/ChainSelect.tsx
@@ -174,10 +174,10 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
 
                 {isSelected && clearable && (
                   <Button
-                    label="clear"
+                    label="Clear"
                     size="sm"
                     variant="outline"
-                    className="ml-4 max-w-8"
+                    className="ml-4 max-w-[4.875rem]"
                     onClick={() => {
                       onChange(null)
                       setIsOpen(false)

--- a/app/src/components/ChainSelect.tsx
+++ b/app/src/components/ChainSelect.tsx
@@ -10,6 +10,7 @@ import { forwardRef, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { normalize } from 'viem/ens'
 import { useEnsAvatar } from 'wagmi'
+import { colors } from '../../tailwind.config'
 import Button from './Button'
 import Dropdown from './Dropdown'
 import ChainIcon from './svg/ChainIcon'
@@ -187,8 +188,8 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
                       setIsOpen(false)
                     }}
                   >
-                    <div className="mr-1 flex items-center">
-                      <Cross stroke="black" />
+                    <div className="mr-1 flex items-center gap-1 text-turtle-foreground">
+                      <Cross stroke={colors['turtle-foreground']} />
                       <span>Clear</span>
                     </div>
                   </Button>

--- a/app/src/components/ChainSelect.tsx
+++ b/app/src/components/ChainSelect.tsx
@@ -158,7 +158,10 @@ const ChainSelect = forwardRef<HTMLDivElement, ChainSelectProps>(
             return (
               <li
                 key={option.uid}
-                className="flex cursor-pointer items-center justify-between px-3 py-3 hover:bg-turtle-level1"
+                className={cn(
+                  'flex cursor-pointer items-center justify-between px-3 py-3 hover:bg-turtle-level1',
+                  isSelected && 'bg-turtle-secondary-light hover:bg-turtle-secondary-light',
+                )}
                 onClick={() => handleSelectionChange(option)}
               >
                 <div className="flex items-center gap-2">

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -3,6 +3,7 @@ import useErc20Allowance from '@/hooks/useErc20Allowance'
 import useEthForWEthSwap from '@/hooks/useEthForWEthSwap'
 import useSnowbridgeContext from '@/hooks/useSnowbridgeContext'
 import useTransferForm from '@/hooks/useTransferForm'
+import { Chain } from '@/models/chain'
 import { resolveDirection } from '@/services/transfer'
 import { cn } from '@/utils/cn'
 import {
@@ -228,11 +229,11 @@ const Transfer: FC = () => {
               tokenAmount!.token,
             )
 
-            const reorderedOptions = reorderOptionsBySelectedItem(
-              options,
-              'uid',
-              destinationChain?.uid,
-            )
+            const reorderedOptions = reorderOptionsBySelectedItem<
+              Chain & {
+                allowed: boolean
+              }
+            >(options, 'uid', destinationChain?.uid)
 
             return (
               <ChainSelect

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -218,6 +218,7 @@ const Transfer: FC = () => {
                   <WalletButton walletType={destinationChain?.walletType} />
                 )
               }
+              clearable
               walletAddress={destinationWallet?.sender?.address}
               className="z-30"
               disabled={transferStatus !== 'Idle' || !sourceChain || !tokenAmount?.token}

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -10,6 +10,7 @@ import {
   getAllowedSourceChains,
   getAllowedTokens,
 } from '@/utils/routes'
+import { reorderOptionsBySelectedItem } from '@/utils/sort'
 import { formatAmount, getDurationEstimate } from '@/utils/transfer'
 import { Signer } from 'ethers'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -143,57 +144,74 @@ const Transfer: FC = () => {
         <Controller
           name="sourceChain"
           control={control}
-          render={({ field }) => (
-            <ChainSelect
-              {...field}
-              onChange={handleSourceChainChange}
-              options={getAllowedSourceChains(environment)}
-              floatingLabel="From"
-              placeholder="Source"
-              trailing={<WalletButton walletType={sourceChain?.walletType} />}
-              walletAddress={sourceWallet?.sender?.address}
-              className="z-50"
-              disabled={transferStatus !== 'Idle'}
-            />
-          )}
+          render={({ field }) => {
+            const options = getAllowedSourceChains(environment)
+            const reorderedOptions = reorderOptionsBySelectedItem(options, 'uid', sourceChain?.uid)
+
+            return (
+              <ChainSelect
+                {...field}
+                onChange={handleSourceChainChange}
+                options={reorderedOptions}
+                floatingLabel="From"
+                placeholder="Source"
+                trailing={<WalletButton walletType={sourceChain?.walletType} />}
+                walletAddress={sourceWallet?.sender?.address}
+                className="z-50"
+                disabled={transferStatus !== 'Idle'}
+              />
+            )
+          }}
         />
 
         {/* Token */}
         <Controller
           name="tokenAmount"
           control={control}
-          render={({ field }) => (
-            <TokenAmountSelect
-              {...field}
-              sourceChain={sourceChain}
-              options={getAllowedTokens(environment, sourceChain, destinationChain).map(token => ({
+          render={({ field }) => {
+            const options = getAllowedTokens(environment, sourceChain, destinationChain).map(
+              token => ({
                 token,
                 amount: null,
                 allowed: token.allowed,
-              }))}
-              floatingLabel="Amount"
-              disabled={transferStatus !== 'Idle' || !sourceChain}
-              secondPlaceholder={amountPlaceholder}
-              error={errors.tokenAmount?.amount?.message || tokenAmountError}
-              trailing={
-                <Button
-                  label="Max"
-                  size="sm"
-                  variant="outline"
-                  className="min-w-[40px]"
-                  onClick={handleMaxButtonClick}
-                  disabled={
-                    !sourceWallet?.isConnected ||
-                    !tokenAmount?.token ||
-                    !isBalanceAvailable ||
-                    balanceData?.value === 0n ||
-                    transferStatus !== 'Idle'
-                  }
-                />
-              }
-              className="z-40"
-            />
-          )}
+              }),
+            )
+
+            const reorderedOptions = reorderOptionsBySelectedItem(
+              options,
+              'token.id',
+              tokenAmount?.token?.id,
+            )
+
+            return (
+              <TokenAmountSelect
+                {...field}
+                sourceChain={sourceChain}
+                options={reorderedOptions}
+                floatingLabel="Amount"
+                disabled={transferStatus !== 'Idle' || !sourceChain}
+                secondPlaceholder={amountPlaceholder}
+                error={errors.tokenAmount?.amount?.message || tokenAmountError}
+                trailing={
+                  <Button
+                    label="Max"
+                    size="sm"
+                    variant="outline"
+                    className="min-w-[40px]"
+                    onClick={handleMaxButtonClick}
+                    disabled={
+                      !sourceWallet?.isConnected ||
+                      !tokenAmount?.token ||
+                      !isBalanceAvailable ||
+                      balanceData?.value === 0n ||
+                      transferStatus !== 'Idle'
+                    }
+                  />
+                }
+                className="z-40"
+              />
+            )
+          }}
         />
 
         {/* Swap source and destination chains */}
@@ -203,27 +221,41 @@ const Transfer: FC = () => {
         <Controller
           name="destinationChain"
           control={control}
-          render={({ field }) => (
-            <ChainSelect
-              {...field}
-              onChange={handleDestinationChainChange}
-              options={getAllowedDestinationChains(environment, sourceChain, tokenAmount!.token)}
-              floatingLabel="To"
-              placeholder="Destination"
-              manualRecipient={manualRecipient}
-              onChangeManualRecipient={handleManualRecipientChange}
-              error={manualRecipient.enabled ? manualRecipientError : ''}
-              trailing={
-                shouldDisplayRecipientWalletButton && (
-                  <WalletButton walletType={destinationChain?.walletType} />
-                )
-              }
-              clearable
-              walletAddress={destinationWallet?.sender?.address}
-              className="z-30"
-              disabled={transferStatus !== 'Idle' || !sourceChain || !tokenAmount?.token}
-            />
-          )}
+          render={({ field }) => {
+            const options = getAllowedDestinationChains(
+              environment,
+              sourceChain,
+              tokenAmount!.token,
+            )
+
+            const reorderedOptions = reorderOptionsBySelectedItem(
+              options,
+              'uid',
+              destinationChain?.uid,
+            )
+
+            return (
+              <ChainSelect
+                {...field}
+                onChange={handleDestinationChainChange}
+                options={reorderedOptions}
+                floatingLabel="To"
+                placeholder="Destination"
+                manualRecipient={manualRecipient}
+                onChangeManualRecipient={handleManualRecipientChange}
+                error={manualRecipient.enabled ? manualRecipientError : ''}
+                trailing={
+                  shouldDisplayRecipientWalletButton && (
+                    <WalletButton walletType={destinationChain?.walletType} />
+                  )
+                }
+                clearable
+                walletAddress={destinationWallet?.sender?.address}
+                className="z-30"
+                disabled={transferStatus !== 'Idle' || !sourceChain || !tokenAmount?.token}
+              />
+            )
+          }}
         />
       </div>
 

--- a/app/src/components/svg/Cross.tsx
+++ b/app/src/components/svg/Cross.tsx
@@ -1,0 +1,19 @@
+import { ComponentPropsWithoutRef } from 'react'
+import { colors } from '../../../tailwind.config'
+
+export const Cross = ({
+  stroke = colors['turtle-secondary'],
+  ...props
+}: ComponentPropsWithoutRef<'svg'> & { stroke?: string }) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path d="M7 7L17 17" stroke={stroke} strokeLinecap="round" />
+    <path d="M17 7L7 17" stroke={stroke} strokeLinecap="round" />
+  </svg>
+)

--- a/app/src/models/select.ts
+++ b/app/src/models/select.ts
@@ -11,6 +11,7 @@ export interface SelectProps<T> {
   secondPlaceholder?: string
   trailing?: ReactNode
   disabled?: boolean
+  clearable?: boolean
   error?: string
   className?: string
 }

--- a/app/src/utils/sort.ts
+++ b/app/src/utils/sort.ts
@@ -15,21 +15,17 @@ export const reorderOptionsBySelectedItem = <T>(
 
   const getValue = <T>(obj: T, keyPath: string): string | undefined => {
     return keyPath.split('.').reduce((value: unknown, key: string) => {
-      if (value && typeof value === 'object') {
-        return (value as Record<string, unknown>)[key]
-      }
+      if (value && typeof value === 'object') return (value as Record<string, unknown>)[key]
+
       return undefined
     }, obj) as string | undefined
   }
 
   const reorderedOptions: T[] = []
   options.forEach(option => {
-    const uniqueId = getValue(option, key)
-    if (uniqueId === selectedId) {
-      reorderedOptions.unshift(option)
-    } else {
-      reorderedOptions.push(option)
-    }
+    const uniqueId = getValue<T>(option, key)
+    if (uniqueId === selectedId) reorderedOptions.unshift(option)
+    else reorderedOptions.push(option)
   })
 
   return reorderedOptions

--- a/app/src/utils/sort.ts
+++ b/app/src/utils/sort.ts
@@ -1,0 +1,36 @@
+/**
+ * Reorders the options to place the selected item at the top. Can be used for chains or tokens.
+ *
+ * @param options - Array of items to sort.
+ * @param key - Key or path to the unique identifier in the objects (e.g., 'uid' or 'token.id').
+ * @param selectedId - 'uid' or 'id' of the selected item.
+ * @returns A new array with the selected item at the top, others in their original order.
+ */
+export const reorderOptionsBySelectedItem = <T>(
+  options: T[],
+  key: string,
+  selectedId?: string,
+): T[] => {
+  if (!selectedId) return options
+
+  const getValue = <T>(obj: T, keyPath: string): string | undefined => {
+    return keyPath.split('.').reduce((value: unknown, key: string) => {
+      if (value && typeof value === 'object') {
+        return (value as Record<string, unknown>)[key]
+      }
+      return undefined
+    }, obj) as string | undefined
+  }
+
+  const reorderedOptions: T[] = []
+  options.forEach(option => {
+    const uniqueId = getValue(option, key)
+    if (uniqueId === selectedId) {
+      reorderedOptions.unshift(option)
+    } else {
+      reorderedOptions.push(option)
+    }
+  })
+
+  return reorderedOptions
+}


### PR DESCRIPTION
This PR
- reorders chains and tokens so the selected one is at the top in the dropdown
- enables clearing capability. I only enabled it for the dest chain as it only makes sense there.

Fixes VEL-224

![image](https://github.com/user-attachments/assets/15eee751-5fbf-44d3-ab8e-43e6b09b1a30)
