### PR TITLE
fix: unexpected fee triggers on source chain changes

### DIFF
--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -104,12 +104,10 @@ const useTransferForm = () => {
 
   const handleSourceChainChange = useCallback(
     async (newValue: Chain | null) => {
-      setValue('sourceChain', newValue)
-
-      if (newValue?.uid === Ethereum.uid) await switchChain(config, { chainId: mainnet.id }) // needed to fetch balance correctly
-
       if (!newValue || newValue.uid === sourceChain?.uid) return
       const isSameDestination = destinationChain?.uid === newValue.uid
+
+      if (newValue.uid === Ethereum.uid) await switchChain(config, { chainId: mainnet.id }) // needed to fetch balance correctly
 
       if (
         destinationChain &&
@@ -117,6 +115,8 @@ const useTransferForm = () => {
         !isSameDestination &&
         isRouteAllowed(environment, newValue, destinationChain, tokenAmount)
       ) {
+        // Update the source chain here to prevent triggering unexpected states, e.g., the useFees hook.
+        setValue('sourceChain', newValue)
         return
       }
 
@@ -124,10 +124,14 @@ const useTransferForm = () => {
         !isSameDestination &&
         isTokenAvailableForSourceChain(environment, newValue, destinationChain, tokenAmount?.token)
       ) {
+        // Update the source chain here to prevent triggering unexpected states, e.g., the useFees hook.
+        setValue('sourceChain', newValue)
         return
       }
 
+      // Update the source chain here to prevent triggering unexpected states, e.g., the useFees hook.
       // Reset destination and token only if the conditions above are not met
+      setValue('sourceChain', newValue)
       setValue('destinationChain', null)
       setValue('tokenAmount', { token: null, amount: null })
     },


### PR DESCRIPTION
Fixes the unexpected fee triggers on source chain changes. 

_**To reproduce the issue in production:**_
- Select a between parachains transfers ex: AH => USDC => Bifrost. 
- Update source chain to Eth. 
- The fees are triggered with the wrong data throwing an error. 

![image](https://github.com/user-attachments/assets/031b6955-b9c3-4a0a-9328-81a8ee8d6f5e)

![image](https://github.com/user-attachments/assets/1d35f8b8-14dd-428f-be91-b3cb5447e4d1)
