### PR TITLE
fix: usdt revoke allowance

### DIFF
--- a/app/src/components/ActionBanner.tsx
+++ b/app/src/components/ActionBanner.tsx
@@ -22,7 +22,7 @@ const ActionBanner: FC<Props> = ({ disabled, header, text, image, btn }) => {
         disabled ? 'animate-pulse cursor-progress' : '',
       )}
     >
-      <div className="justify-items flex flex-row items-start">
+      <div className="justify-items flex flex-row items-center">
         {image}
         <div className="justify-left ml-3 flex flex-col">
           <div className="text-left text-small font-bold text-turtle-foreground">{header}</div>

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -30,6 +30,7 @@ import Switch from './Switch'
 import TokenAmountSelect from './TokenAmountSelect'
 import TxSummary from './TxSummary'
 import WalletButton from './WalletButton'
+import { EthereumTokens } from '@/registry/mainnet/tokens'
 
 const Transfer: FC = () => {
   const { snowbridgeContext } = useSnowbridgeContext()
@@ -137,6 +138,9 @@ const Transfer: FC = () => {
 
   const shouldDisplayTxSummary =
     tokenAmount?.token && !allowanceLoading && !requiresErc20SpendApproval
+
+  const shouldDisplayUsdtRevokeAllowance =
+    erc20SpendAllowance !== 0 && tokenAmount?.token?.id === EthereumTokens.USDT.id
 
   return (
     <form
@@ -317,7 +321,7 @@ const Transfer: FC = () => {
             <ActionBanner
               disabled={isApprovingErc20Spend}
               header="Approve ERC-20 token spend"
-              text="We first need your approval to transfer this token from your wallet."
+              text={`We first need your approval to transfer this token from your wallet. ${shouldDisplayUsdtRevokeAllowance ? 'USDT requires revoking the current allowance before setting a new one.' : ''}`}
               image={
                 <Image src={'/wallet.svg'} alt={'Wallet illustration'} width={64} height={64} />
               }

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -55,7 +55,7 @@ const TxSummary: FC<TxSummaryProps> = ({
             Loading fees
           </div>
           <Delayed millis={7000}>
-            <div className="animate-slide-up-soft mt-1 text-xs text-turtle-secondary">
+            <div className="animate-slide-up-soft mt-1 text-center text-xs text-turtle-secondary">
               Sorry that it&apos;s taking so long. Hang on or try again
             </div>
           </Delayed>

--- a/app/src/hooks/useErc20Allowance.tsx
+++ b/app/src/hooks/useErc20Allowance.tsx
@@ -89,7 +89,6 @@ const useErc20Allowance = ({ network, tokenAmount, owner, context, refetchFees }
             await toPolkadot
               .approveTokenSpend(context, signer, tokenAmount!.token!.address, 0n)
               .then(x => x.wait())
-              .then(_ => console.log('refetch'))
               .then(_ => fetchAllowance())
           }
         }


### PR DESCRIPTION
This PR fixes the USDT allowance issue. 

The USDT smart contract first requires the revoke of the current allowance before setting the new one. 
**It's a two-signature process.** 

I added the following extra info when needed: 
<img width="663" alt="Capture d’écran 2025-02-10 à 10 43 09" src="https://github.com/user-attachments/assets/ac9d7bbe-db4b-4a59-9aed-e7f516186af2" />


