### PR TITLE
fix: one-click transfer tracking flow

### DIFF
--- a/app/src/app/api/history/route.ts
+++ b/app/src/app/api/history/route.ts
@@ -28,13 +28,7 @@ const getCachedTransferHistory = unstable_cache(
       ongoingTransfers.map(transfer => {
         switch (transfer.direction) {
           case Direction.ToEthereum: {
-            if (transfer.sourceChain.chainId === snowbridgeEnv.config.ASSET_HUB_PARAID) {
-              transfers.toEthereum.push(transfer)
-            } else {
-              console.log('Direct Parachain => Eth tracking')
-              console.log('If/Else to be removed once tested')
-              transfers.toEthereum.push(transfer)
-            }
+            transfers.toEthereum.push(transfer)
             break
           }
           case Direction.ToPolkadot: {

--- a/app/src/hooks/useTransferProgress.tsx
+++ b/app/src/hooks/useTransferProgress.tsx
@@ -3,8 +3,8 @@ import { StoredTransfer } from '@/models/transfer'
 import { Direction } from '@/services/transfer'
 
 const ESTIMATED_DURATION = {
-  toEthereum: 4 * 60 * 60, // 30 mins in seconds
-  toPolkadot: 30 * 60, // 4h in seconds
+  toEthereum: 2 * 60 * 60, // 2 h in seconds
+  toPolkadot: 30 * 60, // 30mins in seconds
   xcmTransfer: 30, // 30 seconds
 }
 

--- a/app/src/store/completedTransfersStore.ts
+++ b/app/src/store/completedTransfersStore.ts
@@ -1,10 +1,17 @@
-import { CompletedTransfer } from '@/models/transfer'
+import { AmountInfo, CompletedTransfer } from '@/models/transfer'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
 interface CompletedTxState {
   completedTransfers: CompletedTransfer[]
   addCompletedTransfer: (completedTransfer: CompletedTransfer) => void
+}
+
+const serializeFeeAmount = (fees: AmountInfo): AmountInfo => {
+  return {
+    ...fees,
+    amount: fees.amount.toString(),
+  }
 }
 
 export const useCompletedTransfersStore = create<CompletedTxState>()(
@@ -18,10 +25,10 @@ export const useCompletedTransfersStore = create<CompletedTxState>()(
         // needed to not run into bigint persistence issues
         const persistableTransfer = {
           ...newCompletedTransfer,
-          fees: {
-            ...newCompletedTransfer.fees,
-            amount: newCompletedTransfer.fees.amount.toString(),
-          },
+          fees: serializeFeeAmount(newCompletedTransfer.fees),
+          ...(newCompletedTransfer.bridgingFee && {
+            bridgingFee: serializeFeeAmount(newCompletedTransfer.bridgingFee),
+          }),
         }
 
         set(state => {

--- a/app/src/utils/transferTracking.ts
+++ b/app/src/utils/transferTracking.ts
@@ -181,12 +181,22 @@ export const findMatchingTransfer = (
 ) =>
   transfers.find(transfer => {
     if ('submitted' in transfer) {
-      if (resolveDirection(ongoingTransfer.sourceChain, ongoingTransfer.destChain) === 'ToEthereum')
-        return transfer.id === ongoingTransfer.parachainMessageId
-      return transfer.id === ongoingTransfer.id
+      if (
+        resolveDirection(ongoingTransfer.sourceChain, ongoingTransfer.destChain) === 'ToEthereum'
+      ) {
+        return (
+          transfer.id === ongoingTransfer.parachainMessageId ||
+          ('extrinsic_hash' in transfer.submitted &&
+            transfer.submitted.extrinsic_hash === ongoingTransfer.id)
+        )
+      } else {
+        return transfer.id === ongoingTransfer.id
+      }
     }
+
     if (ongoingTransfer.crossChainMessageHash)
       return transfer.messageHash === ongoingTransfer.crossChainMessageHash
+
     if (ongoingTransfer.sourceChainExtrinsicIndex)
       return transfer.extrinsicIndex === ongoingTransfer.sourceChainExtrinsicIndex
 

--- a/app/src/utils/transferTracking.ts
+++ b/app/src/utils/transferTracking.ts
@@ -5,6 +5,7 @@ import { FromParachainTrackingResult } from '@/models/subscan'
 import { TransferStatus } from '@snowbridge/api/dist/history'
 import { historyV2 as history } from '@snowbridge/api'
 import { FromAhToEthTrackingResult, FromEthTrackingResult } from '@/models/snowbridge'
+import { resolveDirection } from '@/services/transfer'
 
 export const trackTransfers = async (
   env: environment.SnowbridgeEnvironment,
@@ -21,7 +22,7 @@ export const trackTransfers = async (
   for (const transfer of toEthereum) {
     const tx = await history.toEthereumTransferById(
       transfer.parachainMessageId ? transfer.parachainMessageId : transfer.id,
-    ) // must be {messageId_eq: "${id}", OR: {txHash_eq: "${id}"}
+    )
     if (tx) transfers.push(tx)
   }
 
@@ -94,6 +95,9 @@ export function getTransferStatusFromParachain(
   const isBHChannelMsgDelivered =
     'bridgeHubChannelDelivered' in transferResult &&
     transferResult.bridgeHubChannelDelivered?.success
+
+  const isBHXcmDelivered =
+    'bridgeHubXcmDelivered' in transferResult && transferResult.bridgeHubXcmDelivered?.success
   /** Destination chain is Ethereum in XCM transfer*/
   const isDestChainEthereum =
     'destChain' in transferResult && transferResult.destChain === 'ethereum'
@@ -102,7 +106,8 @@ export function getTransferStatusFromParachain(
 
   switch (transferResult.status) {
     case TransferStatus.Pending:
-      if (isBHChannelMsgDelivered || isDestChainEthereum) return 'Arriving at Ethereum'
+      if (isBHChannelMsgDelivered || isBHXcmDelivered || isDestChainEthereum)
+        return 'Arriving at Ethereum'
       if (isBridgeTransferSubmitted) return 'Arriving at Bridge Hub'
       // Default when the above conditions are not met
       return 'Pending'
@@ -175,7 +180,11 @@ export const findMatchingTransfer = (
   ongoingTransfer: StoredTransfer,
 ) =>
   transfers.find(transfer => {
-    if ('submitted' in transfer) return transfer.id === ongoingTransfer.id
+    if ('submitted' in transfer) {
+      if (resolveDirection(ongoingTransfer.sourceChain, ongoingTransfer.destChain) === 'ToEthereum')
+        return transfer.id === ongoingTransfer.parachainMessageId
+      return transfer.id === ongoingTransfer.id
+    }
     if (ongoingTransfer.crossChainMessageHash)
       return transfer.messageHash === ongoingTransfer.crossChainMessageHash
     if (ongoingTransfer.sourceChainExtrinsicIndex)


### PR DESCRIPTION
This PR fixes the one-click transfer tracking flow. 
_To be noted, the last Hydration direct transfer to ETH took 3h30 against the 1.5 hours estimation we display._ 