### PR TITLE
imp: Move sb registry instantiation to `useSnowbridgeContext`

### DIFF
--- a/app/src/hooks/useFees.tsx
+++ b/app/src/hooks/useFees.tsx
@@ -86,11 +86,7 @@ const useFees = (
           })
           setCanPayFees(info.sufficientForXCM)
 
-          if (
-            destinationChain.network === 'Ethereum' &&
-            !isAssetHub(sourceChain) &&
-            snowbridgeContext
-          ) {
+          if (destinationChain.network === 'Ethereum' && snowbridgeContext) {
             const bridgeFeeToken = PolkadotTokens.DOT
             const bridgeFeeTokenInDollars = (await getCachedTokenPrice(bridgeFeeToken))?.usd ?? 0
             const bridgingFee = await getCachedBridgingFee()

--- a/app/src/hooks/useFees.tsx
+++ b/app/src/hooks/useFees.tsx
@@ -15,7 +15,6 @@ import useSnowbridgeContext from './useSnowbridgeContext'
 import { getRoute } from '@/utils/routes'
 import { getFeeEstimate } from '@/utils/snowbridge'
 import { PolkadotTokens } from '@/registry/mainnet/tokens'
-import { isAssetHub } from '@/registry/helpers'
 import { getBalance } from './useBalance'
 
 // NOTE: when bridging from Parachain -> Ethereum, we have the local execution fees + the bridging fees.
@@ -86,7 +85,10 @@ const useFees = (
           })
           setCanPayFees(info.sufficientForXCM)
 
-          if (destinationChain.network === 'Ethereum' && snowbridgeContext) {
+          if (
+            destinationChain.network === 'Ethereum' &&
+            snowbridgeContext
+          ) {
             const bridgeFeeToken = PolkadotTokens.DOT
             const bridgeFeeTokenInDollars = (await getCachedTokenPrice(bridgeFeeToken))?.usd ?? 0
             const bridgingFee = await getCachedBridgingFee()

--- a/app/src/hooks/useFees.tsx
+++ b/app/src/hooks/useFees.tsx
@@ -85,10 +85,7 @@ const useFees = (
           })
           setCanPayFees(info.sufficientForXCM)
 
-          if (
-            destinationChain.network === 'Ethereum' &&
-            snowbridgeContext
-          ) {
+          if (destinationChain.network === 'Ethereum' && snowbridgeContext) {
             const bridgeFeeToken = PolkadotTokens.DOT
             const bridgeFeeTokenInDollars = (await getCachedTokenPrice(bridgeFeeToken))?.usd ?? 0
             const bridgingFee = await getCachedBridgingFee()

--- a/app/src/hooks/useSnowbridgeContext.tsx
+++ b/app/src/hooks/useSnowbridgeContext.tsx
@@ -1,5 +1,7 @@
 import { getSnowBridgeContext } from '@/context/snowbridge'
 import useEnvironment from '@/hooks/useEnvironment'
+import { SnowbridgeContext } from '@/models/snowbridge'
+import { assetsV2 } from '@snowbridge/api'
 import { useQuery } from '@tanstack/react-query'
 
 const useSnowbridgeContext = () => {
@@ -12,9 +14,12 @@ const useSnowbridgeContext = () => {
   } = useQuery({
     queryKey: ['snowbridgeContext', environment],
     queryFn: async () => {
-      return await getSnowBridgeContext(environment)
+      const ctx = (await getSnowBridgeContext(environment)) as SnowbridgeContext
+      ctx.registry = await assetsV2.buildRegistry(await assetsV2.fromContext(ctx))
+
+      return ctx
     },
-    staleTime: Infinity,
+    staleTime: 43200000, // 12 hours in milliseconds
     retry: 3,
     retryDelay: attemptIndex => Math.min(1000 * 2 ** attemptIndex, 30000),
   })

--- a/app/src/models/snowbridge.ts
+++ b/app/src/models/snowbridge.ts
@@ -1,9 +1,11 @@
-import { historyV2 as history } from '@snowbridge/api'
+import { historyV2 as history, assetsV2, Context } from '@snowbridge/api'
 
 export type SnowbridgeStatus = {
   toEthereum: number
   toPolkadot: number
 }
+
+export type SnowbridgeContext = Context & { registry: assetsV2.AssetRegistry }
 
 export type FromEthTrackingResult = history.ToPolkadotTransferResult
 export type FromAhToEthTrackingResult = history.ToEthereumTransferResult

--- a/app/src/registry/mainnet/routes.ts
+++ b/app/src/registry/mainnet/routes.ts
@@ -62,7 +62,7 @@ export const routes: Route[] = [
   {
     from: AssetHub.uid,
     to: Ethereum.uid,
-    sdk: 'SnowbridgeApi',
+    sdk: 'ParaSpellApi',
     tokens: [
       EthereumTokens.WETH.id,
       EthereumTokens.WBTC.id,


### PR DESCRIPTION
We get caching and unify both in one intersected type so that we don't have to keep track of two hooks and two values around the codebase. We might want to cache this server side in the future but for now caching client side for 12 hours should be fine.