### PR TITLE
fix: Validate SB-based transfers before estimating execution fees

### DIFF
--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -111,7 +111,7 @@ const useTransferForm = () => {
       isRouteAllowed(environment, sourceChain, destinationChain) &&
       isRouteAllowed(environment, destinationChain, sourceChain, tokenAmount)
     )
-  }, [environment, destinationChain, sourceChain, tokenAmount, isValidating, transferStatus])
+  }, [environment, destinationChain, sourceChain, tokenAmount, isValidating, transferStatus, tokenAmountError])
 
   const handleSourceChainChange = useCallback(
     async (newValue: Chain | null) => {

--- a/app/src/hooks/useTransferForm.tsx
+++ b/app/src/hooks/useTransferForm.tsx
@@ -111,7 +111,15 @@ const useTransferForm = () => {
       isRouteAllowed(environment, sourceChain, destinationChain) &&
       isRouteAllowed(environment, destinationChain, sourceChain, tokenAmount)
     )
-  }, [environment, destinationChain, sourceChain, tokenAmount, isValidating, transferStatus, tokenAmountError])
+  }, [
+    environment,
+    destinationChain,
+    sourceChain,
+    tokenAmount,
+    isValidating,
+    transferStatus,
+    tokenAmountError,
+  ])
 
   const handleSourceChainChange = useCallback(
     async (newValue: Chain | null) => {

--- a/app/src/utils/snowbridge.ts
+++ b/app/src/utils/snowbridge.ts
@@ -119,8 +119,8 @@ export const getFeeEstimate = async (
           },
           tx,
         )
-        
-        if (checkValidation(validation) === 'Failed')
+
+        if (findValidationError(validation))
           return {
             origin: 'Ethereum',
             bridging: bridgingFee,
@@ -128,7 +128,6 @@ export const getFeeEstimate = async (
           }
 
         const executionFee = await estimateTransactionFees(tx, context, feeToken, feeTokenInDollars)
-
         return {
           origin: 'Ethereum',
           bridging: bridgingFee,
@@ -156,10 +155,8 @@ export const getFeeEstimate = async (
   }
 }
 
-export const checkValidation = (
-    validation: toPolkadotV2.ValidationResult | toEthereumV2.ValidationResult,
-  ): 'Succeeded' | 'Failed' => {
-    const error = validation.logs.find(log => log.kind == toPolkadotV2.ValidationKind.Error)
-    
-    return error ? 'Failed' : 'Succeeded'
-  }
+export const findValidationError = (
+  validation: toPolkadotV2.ValidationResult | toEthereumV2.ValidationResult,
+): toPolkadotV2.ValidationLog | toEthereumV2.ValidationLog | undefined => {
+  return validation.logs.find(log => log.kind == toPolkadotV2.ValidationKind.Error)
+}


### PR DESCRIPTION
Fixes https://velocity-labs.sentry.io/issues/29823189/replays/

Basically validate the transfer before going ahead with estimating execution fees which fails if the tx is invalid.