### PR TITLE
Remove inline object literals from components props

### DIFF
--- a/app/src/app/error.tsx
+++ b/app/src/app/error.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { captureException } from '@sentry/nextjs'
 
+const imageStyles = { objectFit: 'cover' as const }
+
 const Error = ({ error }: { error: Error & { digest?: string } }) => {
   useEffect(() => {
     captureException(error)
@@ -17,7 +19,7 @@ const Error = ({ error }: { error: Error & { digest?: string } }) => {
         alt="Turtle Background"
         className="relative z-0"
         fill
-        style={{ objectFit: 'cover' }}
+        style={imageStyles}
         sizes="100vw"
         priority
       />

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -4,6 +4,8 @@ import { useEffect } from 'react'
 import Image from 'next/image'
 import Navbar from '@/components/NavBar'
 
+const imageStyles = { objectFit: 'cover' as const }
+
 const GlobalError = ({ error }: { error: Error & { digest?: string } }) => {
   useEffect(() => {
     captureException(error)
@@ -18,7 +20,7 @@ const GlobalError = ({ error }: { error: Error & { digest?: string } }) => {
           alt="Turtle Background"
           className="relative z-0"
           fill
-          style={{ objectFit: 'cover' }}
+          style={imageStyles}
           sizes="100vw"
           priority
         />

--- a/app/src/app/not-found.tsx
+++ b/app/src/app/not-found.tsx
@@ -1,6 +1,8 @@
 import Image from 'next/image'
 import Link from 'next/link'
 
+const imageStyles = { objectFit: 'cover' as const }
+
 const NotFound = () => {
   return (
     <div className="w-full">
@@ -10,7 +12,7 @@ const NotFound = () => {
         alt="Turtle Background for not found 404 page"
         className="relative z-0"
         fill
-        style={{ objectFit: 'cover' }}
+        style={imageStyles}
         sizes="100vw"
         priority
       />

--- a/app/src/components/Button.tsx
+++ b/app/src/components/Button.tsx
@@ -7,7 +7,7 @@ import LoadingIcon from './svg/LoadingIcon'
 export type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'update'
 type ButtonSize = 'xs' | 'sm' | 'md' | 'lg'
 
-const styles = {
+const classes = {
   primary:
     'bg-turtle-primary border border-black hover:border-black focus:border-black active:border-black disabled:border-black disabled:opacity-30',
   secondary:
@@ -17,6 +17,10 @@ const styles = {
   ghost: 'bg-transparent disabled:opacity-30',
   update:
     'border-1 bg-turtle-secondary border border-turtle-secondary-dark text-turtle-secondary-dark disabled:opacity-100 disabled:bg-opacity-50 disabled:border-opacity-40',
+}
+
+const styles = {
+  outline: 'none',
 }
 
 const sizeHeights: Record<ButtonSize, string> = {
@@ -92,11 +96,9 @@ const Button: FC<ButtonProps> = ({
       size={size === 'xs' ? 'sm' : size}
       radius="sm"
       disableAnimation={true}
-      className={twMerge('w-full', styles[variant], sizeHeights[size], paddingX[size], className)}
+      className={twMerge('w-full', classes[variant], sizeHeights[size], paddingX[size], className)}
       type={type}
-      style={{
-        outline: 'none',
-      }}
+      style={styles}
       data-cy={cypressID}
     >
       {/** Loading state */}

--- a/app/src/components/Dropdown.tsx
+++ b/app/src/components/Dropdown.tsx
@@ -7,26 +7,30 @@ interface DropdownProps {
   children: ReactNode
 }
 
+const dropdownAnimationProps = {
+  initial: { height: '3.6rem' },
+  animate: {
+    height: 'auto',
+    transition: {
+      type: 'spring',
+      bounce: 0.4,
+      duration: 0.3,
+    },
+  },
+  exit: {
+    height: '3.6rem',
+    transition: { duration: 0.06 },
+  },
+}
+
 const Dropdown: FC<DropdownProps> = ({ isOpen, dropdownRef, children }) => {
   return (
     <AnimatePresence>
       {isOpen && (
         <motion.div
           ref={dropdownRef}
-          initial={{ height: '3.6rem' }}
-          animate={{
-            height: 'auto',
-            transition: {
-              type: 'spring',
-              bounce: 0.4,
-              duration: 0.3,
-            },
-          }}
-          exit={{
-            height: '3.6rem',
-            transition: { duration: 0.06 },
-          }}
           className="absolute left-0 right-0 top-0 z-20 max-h-[16.5rem] overflow-y-auto rounded-md border-1 border-turtle-level3 bg-white shadow-2xl"
+          {...dropdownAnimationProps}
         >
           <ul className="flex flex-col pt-2">{children}</ul>
         </motion.div>

--- a/app/src/components/NotificationToast.tsx
+++ b/app/src/components/NotificationToast.tsx
@@ -12,6 +12,13 @@ import { twMerge } from 'tailwind-merge'
 
 const NOTIFICATION_TTL_MS = 5000
 
+const motionProps = {
+  initial: { y: -15, scale: 0.95 },
+  animate: { y: 0, scale: 1 },
+  exit: { x: '100%', opacity: 0 },
+  transition: { duration: 0.35, ease: 'easeOut' },
+}
+
 interface NotificationToastProps {
   notification: Notification
   removeNotification: (id: number) => void
@@ -36,14 +43,11 @@ const NotificationToast: React.FC<NotificationToastProps> = ({
   return (
     <motion.div
       layout
-      initial={{ y: -15, scale: 0.95 }}
-      animate={{ y: 0, scale: 1 }}
-      exit={{ x: '100%', opacity: 0 }}
-      transition={{ duration: 0.35, ease: 'easeOut' }}
       role="alert"
       className={twMerge(
         'pointer-events-auto flex h-[2rem] flex-row items-center gap-[0.25rem] text-nowrap rounded-[8px] bg-turtle-foreground py-[0.25rem] pl-[0.25rem] pr-[0.5rem]',
       )}
+      {...motionProps}
     >
       {/* Notification Icon */}
       {renderSeverityIcon(notification.severity)}

--- a/app/src/components/SubstrateWalletModal.tsx
+++ b/app/src/components/SubstrateWalletModal.tsx
@@ -4,12 +4,19 @@ import { truncateAddress } from '@/utils/address'
 import { getWalletLogo, getWalletName, getWalletWeight } from '@/utils/wallet'
 import type { InjectedAccount, InjectedExtension } from '@polkadot/extension-inject/types'
 import { motion } from 'framer-motion'
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect, useMemo, useState } from 'react'
 import { colors } from '../../tailwind.config'
 import Button, { spinnerSize } from './Button'
 import { Icon } from './Icon'
 import LoadingIcon from './svg/LoadingIcon'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog'
+
+const footerAnimationProps = {
+  initial: { opacity: 0, height: 0 },
+  animate: { opacity: 1, height: 'auto' },
+  exit: { opacity: 0, height: 0 },
+  transition: { duration: 0.3 },
+}
 
 const SubstrateWalletModal: FC = () => {
   const [currentView, setCurrentView] = useState<'extensions' | 'accounts'>('extensions')
@@ -61,6 +68,15 @@ const SubstrateWalletModal: FC = () => {
     type === 'SubstrateEVM' ? account.type === 'ethereum' : account.type === 'sr25519',
   )
 
+  const heightAnimationProps = useMemo(
+    () => ({
+      initial: { height: currentView === 'extensions' ? '10rem' : '11.8rem' },
+      animate: { height: currentView === 'extensions' ? '10rem' : '11.8rem' },
+      transition: { duration: 0.5, type: 'spring' },
+    }),
+    [currentView],
+  )
+
   return (
     <Dialog open={isModalOpen} onOpenChange={open => (open ? openModal() : closeModal())}>
       <DialogContent
@@ -85,9 +101,7 @@ const SubstrateWalletModal: FC = () => {
         <motion.div
           className="flex max-h-[15rem] min-h-[130px] flex-col items-center justify-start space-y-2 overflow-y-auto p-6 pt-3 text-base"
           layout
-          initial={{ height: currentView === 'extensions' ? '10rem' : '11.8rem' }}
-          animate={{ height: currentView === 'extensions' ? '10rem' : '11.8rem' }}
-          transition={{ duration: 0.5, type: 'spring' }}
+          {...heightAnimationProps}
         >
           {/* Loading */}
           {loading && (
@@ -165,13 +179,7 @@ const SubstrateWalletModal: FC = () => {
         </motion.div>
 
         {/* Footer */}
-        <motion.div
-          layout
-          initial={{ opacity: 0, height: 0 }}
-          animate={{ opacity: 1, height: 'auto' }}
-          exit={{ opacity: 0, height: 0 }}
-          transition={{ duration: 0.3 }}
-        >
+        <motion.div layout {...footerAnimationProps}>
           {currentView === 'extensions' && <Footer />}
         </motion.div>
       </DialogContent>

--- a/app/src/components/TokenAmountSelect.tsx
+++ b/app/src/components/TokenAmountSelect.tsx
@@ -20,6 +20,11 @@ export interface TokenAmountSelectProps extends SelectProps<TokenAmount> {
   sourceChain: Chain | null
 }
 
+const numberFlowFormat = {
+  notation: 'compact' as const,
+  maximumFractionDigits: 3,
+}
+
 const TokenAmountSelect = forwardRef<HTMLDivElement, TokenAmountSelectProps>(
   (
     {
@@ -128,10 +133,7 @@ const TokenAmountSelect = forwardRef<HTMLDivElement, TokenAmountSelectProps>(
                     <NumberFlow
                       value={Math.min(inDollars, maxDollars)} // Ensure the value doesn't exceed the max
                       prefix="$"
-                      format={{
-                        notation: 'compact',
-                        maximumFractionDigits: 3,
-                      }}
+                      format={numberFlowFormat}
                     />
                   </div>
                 )}

--- a/app/src/components/Tooltip.tsx
+++ b/app/src/components/Tooltip.tsx
@@ -13,6 +13,15 @@ export interface TooltipProps {
   showArrow?: boolean
 }
 
+const classNames = {
+  base: [
+    // arrow color
+    'before:bg-black before:rounded-[-10px] before:translate-y-[-1px]',
+  ],
+  content: ['p-[4px] rounded-[8px]', 'text-white bg-black'],
+  arrow: ['bg-black'],
+}
+
 export const Tooltip: FC<TooltipProps> = ({
   children,
   content,
@@ -32,14 +41,7 @@ export const Tooltip: FC<TooltipProps> = ({
           {content}
         </div>
       }
-      classNames={{
-        base: [
-          // arrow color
-          'before:bg-black before:rounded-[-10px] before:translate-y-[-1px]',
-        ],
-        content: ['p-[4px] rounded-[8px]', 'text-white bg-black'],
-        arrow: ['bg-black'],
-      }}
+      classNames={classNames}
     >
       {children}
     </NextTooltip>

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -17,7 +17,7 @@ import { formatAmount, getDurationEstimate } from '@/utils/transfer'
 import { Signer } from 'ethers'
 import { AnimatePresence, motion } from 'framer-motion'
 import Image from 'next/image'
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 import { Controller } from 'react-hook-form'
 import ActionBanner from './ActionBanner'
 import Button from './Button'
@@ -31,6 +31,20 @@ import Switch from './Switch'
 import TokenAmountSelect from './TokenAmountSelect'
 import TxSummary from './TxSummary'
 import WalletButton from './WalletButton'
+
+const manualInputAnimationProps = {
+  initial: { opacity: 0, height: 0 },
+  animate: { opacity: 1, height: 'auto' },
+  exit: { opacity: 0, height: 0 },
+  transition: { duration: 0.07 },
+}
+
+const approvalAnimationProps = {
+  initial: { opacity: 0, height: 0 },
+  animate: { opacity: 1, height: 'auto' },
+  exit: { opacity: 0, height: 0 },
+  transition: { duration: 0.3 },
+}
 
 const Transfer: FC = () => {
   const { snowbridgeContext } = useSnowbridgeContext()
@@ -150,6 +164,23 @@ const Transfer: FC = () => {
 
   const shouldDisplayUsdtRevokeAllowance =
     erc20SpendAllowance !== 0 && tokenAmount?.token?.id === EthereumTokens.USDT.id
+
+  const approveAllowanceButton = useMemo(
+    () => ({
+      onClick: () => approveAllowance(sourceWallet?.sender as Signer),
+      label: 'Sign now',
+    }),
+    [approveAllowance, sourceWallet?.sender],
+  )
+
+  const swapEthToWEthButton = useMemo(
+    () => ({
+      onClick: () =>
+        swapEthtoWEth(sourceWallet?.sender as Signer, missingBalance).then(_ => fetchBalance()),
+      label: `Swap the difference`,
+    }),
+    [swapEthtoWEth, sourceWallet?.sender, missingBalance, fetchBalance],
+  )
 
   return (
     <form
@@ -295,14 +326,8 @@ const Transfer: FC = () => {
           <AnimatePresence>
             {manualRecipient.enabled && (
               <motion.div
-                initial={{ opacity: 0, height: 0 }}
-                animate={{
-                  opacity: 1,
-                  height: 'auto',
-                }}
-                exit={{ opacity: 0, height: 0 }}
-                transition={{ duration: 0.07 }}
                 className="flex items-center gap-1 self-center pt-1"
+                {...manualInputAnimationProps}
               >
                 <AlertIcon />
                 <span className="text-xs">Double check the address to avoid losing funds</span>
@@ -316,14 +341,8 @@ const Transfer: FC = () => {
       <AnimatePresence>
         {requiresErc20SpendApproval && (
           <motion.div
-            initial={{ opacity: 0, height: 0 }}
-            animate={{
-              opacity: 1,
-              height: 'auto',
-            }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.3 }}
             className="flex items-center gap-1 self-center pt-1"
+            {...approvalAnimationProps}
           >
             <ActionBanner
               disabled={isApprovingErc20Spend}
@@ -332,10 +351,7 @@ const Transfer: FC = () => {
               image={
                 <Image src={'/wallet.svg'} alt={'Wallet illustration'} width={64} height={64} />
               }
-              btn={{
-                onClick: () => approveAllowance(sourceWallet?.sender as Signer),
-                label: 'Sign now',
-              }}
+              btn={approveAllowanceButton}
             />
           </motion.div>
         )}
@@ -345,28 +361,16 @@ const Transfer: FC = () => {
       <AnimatePresence>
         {shouldDisplayEthToWEthSwap && (
           <motion.div
-            initial={{ opacity: 0, height: 0 }}
-            animate={{
-              opacity: 1,
-              height: 'auto',
-            }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.3 }}
             className="flex items-center gap-1 self-center pt-1"
+            {...approvalAnimationProps}
           >
             <ActionBanner
               disabled={isSwappingEthForWEth}
               header={'Swap ETH for wETH'}
               text={'Your wETH balance is insufficient but you got enough ETH.'}
               image={<Image src={'/wallet.svg'} alt={'Wallet'} width={64} height={64} />}
-              btn={{
-                onClick: () =>
-                  swapEthtoWEth(sourceWallet?.sender as Signer, missingBalance).then(_ =>
-                    fetchBalance(),
-                  ),
-                label: `Swap the difference`,
-              }}
-            ></ActionBanner>
+              btn={swapEthToWEthButton}
+            />
           </motion.div>
         )}
       </AnimatePresence>

--- a/app/src/components/TurtlesBackground.tsx
+++ b/app/src/components/TurtlesBackground.tsx
@@ -1,5 +1,7 @@
 import Image from 'next/image'
 
+const imageStyle = { objectFit: 'cover' as const }
+
 export const TurtlesBackground: React.FC = () => {
   return (
     <div className="absolute top-0 z-0 h-[80vh] w-full">
@@ -8,7 +10,7 @@ export const TurtlesBackground: React.FC = () => {
           src="/turtle-background.webp"
           alt="Turtle Background"
           fill
-          style={{ objectFit: 'cover' }}
+          style={imageStyle}
           quality={100}
           sizes="100vw"
           priority

--- a/app/src/components/TxSummary.tsx
+++ b/app/src/components/TxSummary.tsx
@@ -26,6 +26,16 @@ interface TxSummaryProps {
   className?: string
 }
 
+const animationConfig = {
+  initial: { opacity: 0, height: 0 },
+  animate: {
+    opacity: 1,
+    height: 'auto',
+    transition: { type: 'spring', bounce: 0.6, duration: 0.5 },
+  },
+  exit: { opacity: 0, height: 0, transition: { duration: 0.2 } },
+}
+
 const TxSummary: FC<TxSummaryProps> = ({
   loading,
   tokenAmount,
@@ -176,17 +186,7 @@ const TxSummary: FC<TxSummaryProps> = ({
 
   return (
     <AnimatePresence>
-      <motion.div
-        initial={{ opacity: 0, height: 0 }}
-        animate={{
-          opacity: 1,
-          height: 'auto',
-          transition: { type: 'spring', bounce: 0.6, duration: 0.5 },
-        }}
-        exit={{ opacity: 0, height: 0, transition: { duration: 0.2 } }}
-      >
-        {renderContent()}
-      </motion.div>
+      <motion.div {...animationConfig}>{renderContent()}</motion.div>
     </AnimatePresence>
   )
 }

--- a/app/src/components/WalletButton.tsx
+++ b/app/src/components/WalletButton.tsx
@@ -15,6 +15,12 @@ interface WalletButtonProps {
   className?: string
 }
 
+const walletButtonAnimationProps = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+}
+
 /** Wallet button component that is intended to support connecting to various different networks based on its address type. */
 const WalletButton = ({ walletType, className }: WalletButtonProps) => {
   const {
@@ -78,10 +84,8 @@ const WalletButton = ({ walletType, className }: WalletButtonProps) => {
     <motion.div
       key={walletType}
       className={className}
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
       data-cy="connect-button"
+      {...walletButtonAnimationProps}
     >
       <Button
         label={isConnected ? 'Disconnect' : 'Connect'}

--- a/app/src/components/WalletButton.tsx
+++ b/app/src/components/WalletButton.tsx
@@ -15,7 +15,7 @@ interface WalletButtonProps {
   className?: string
 }
 
-const walletButtonAnimationProps = {
+const animationProps = {
   initial: { opacity: 0 },
   animate: { opacity: 1 },
   exit: { opacity: 0 },
@@ -81,12 +81,7 @@ const WalletButton = ({ walletType, className }: WalletButtonProps) => {
   })()
 
   return (
-    <motion.div
-      key={walletType}
-      className={className}
-      data-cy="connect-button"
-      {...walletButtonAnimationProps}
-    >
+    <motion.div key={walletType} className={className} data-cy="connect-button" {...animationProps}>
       <Button
         label={isConnected ? 'Disconnect' : 'Connect'}
         variant={isConnected ? 'outline' : 'primary'}


### PR DESCRIPTION
This PR addresses a potential performance issue by removing inline object literals from component props.

## Problem
Inlining object literals as props (like `<Component data={{key: value}}/>`) creates a new object instance on every render because JavaScript compares objects by reference, not value. This causes:

1. Unnecessary re-renders: Components using React.memo or PureComponent will re-render even when the actual data hasn't changed.
2. Increased memory usage: Each render creates new object instances that must be garbage collected.
3. Reduced performance: Additional rendering cycles and garbage collection affect application speed.

The same issue occurs when inlining functions `<Button onClick={() => handleClick()}/>` or other components as props `<TabPanelheader={<CustomHeader title="Dashboard" />} />` but these could be addressed in a separate PR.

## Solution
This PR moves inline object literals to component-level constants or file variables:

* Before: `<UserCard settings={{theme: 'dark', showAvatar: true}} />`
* After (outside component): 
  ```jsx
  // Constants defined outside component maintain reference across renders
  const staticSettings = {theme: 'dark', showAvatar: true};
  
  function MyComponent() {
    return <UserCard settings={staticSettings} />;
  }
  ```
* After (with useMemo - for dynamic values):
  ```jsx
  function MyComponent({ userId, isDarkMode }) {
    // Use useMemo when object depends on props or state
    const userSettings = useMemo(() => ({
      theme: isDarkMode ? 'dark' : 'light',
      userId: userId,
      showAvatar: true
    }), [isDarkMode, userId]);
    
    return <UserCard settings={userSettings} />;
  }
  ```

This ensures stable object references between renders, preventing unnecessary re-renders and improving memory efficiency.
