### PR TITLE
chore: Update Relay & Moonbeam's dwellir endpoints

### DIFF
--- a/app/src/registry/mainnet/chains.ts
+++ b/app/src/registry/mainnet/chains.ts
@@ -30,7 +30,7 @@ export const RelayChain: Chain = {
   network: 'Polkadot',
   supportedAddressTypes: ['ss58'],
   walletType: 'Substrate',
-  rpcConnection: `wss://api-polkadot.dwellir.com/${DWELLIR_KEY}`,
+  rpcConnection: `wss://api-polkadot.n.dwellir.com/${DWELLIR_KEY}`,
 }
 
 export const BridgeHub: Chain = {
@@ -88,7 +88,7 @@ export const Moonbeam: Chain = {
   network: 'Polkadot',
   supportedAddressTypes: ['evm'],
   walletType: 'EVM',
-  rpcConnection: `wss://api-moonbeam.dwellir.com/${DWELLIR_KEY}`,
+  rpcConnection: `wss://api-moonbeam.n.dwellir.com/${DWELLIR_KEY}`,
 }
 
 export const Interlay: Chain = {


### PR DESCRIPTION
Addressing a message we got to update these two endpoints

> Hi !
> 
> I'm reaching out because I noticed you are still using one or more of our old endpoints where a new one is available (using the new ones should, in general, lead to better stability and performance).
> 
> 
> Moonbeam
> Old endpoint: [api-moonbeam.dwellir.com](http://api-moonbeam.dwellir.com/) (Usage: Past 30d: 99,645; Past 7d: 33,160; > Past 24hrs: 9,460)
> New endpoint: [api-moonbeam.n.dwellir.com](http://api-moonbeam.n.dwellir.com/) (Usage: 0)
> Polkadot
> Old endpoint: [api-polkadot.dwellir.com](http://api-polkadot.dwellir.com/) (Usage: Past 30d: 505,304; Past 7d: 282,995; > > Past 24hrs: 253,633)
> New endpoint: [api-polkadot.n.dwellir.com](http://api-polkadot.n.dwellir.com/) (Usage: 0)
> 
> Over the coming weeks/months we are migrating to '.n.' endpoints across the entire portfolio of chains and will make sure > to notify you (and all other users) of a given endpoint when such an upgrade occurs.
> 
> This is a soft migration, so you shouldn't experience any service disruptions. But switching to the new endpoints will, as > mentioned previously, give you a better experience.
