### PR TITLE
Refactor useTransferForm dependencies for optimized reactivity

### DIFF
--- a/app/src/hooks/useTransferForm.ts
+++ b/app/src/hooks/useTransferForm.ts
@@ -17,7 +17,7 @@ import { switchChain } from '@wagmi/core'
 import { useCallback, useEffect, useState } from 'react'
 import { SubmitHandler, useForm, useWatch } from 'react-hook-form'
 import { mainnet } from 'viem/chains'
-import { formatAmount } from '../utils/transfer'
+import { formatAmount } from '@/utils/transfer'
 import useFees from './useFees'
 import useNotification from './useNotification'
 
@@ -111,15 +111,7 @@ const useTransferForm = () => {
       isRouteAllowed(environment, sourceChain, destinationChain) &&
       isRouteAllowed(environment, destinationChain, sourceChain, tokenAmount)
     )
-  }, [
-    environment,
-    destinationChain,
-    sourceChain,
-    tokenAmount,
-    isValidating,
-    transferStatus,
-    tokenAmountError,
-  ])
+  }, [environment, destinationChain, sourceChain, tokenAmount, isValidating, transferStatus])
 
   const handleSourceChainChange = useCallback(
     async (newValue: Chain | null) => {
@@ -162,7 +154,7 @@ const useTransferForm = () => {
       setValue('destinationChain', newValue)
       trigger()
     },
-    [setValue],
+    [setValue, trigger],
   )
 
   const swapFromTo = useCallback(() => {


### PR DESCRIPTION
While working on [this PR](https://github.com/velocitylabs-org/turtle/pull/332), I noticed a couple of improvements in the useTransferForm.ts file:
	•	Updated the dependency arrays in useCallback hooks to ensure consistent reactivity and avoid unnecessary re-renders.
	•	Adjusted the import path for formatAmount to use an absolute path, improving consistency across the codebase.