### PR TITLE
Fix animation and transition effects in ProgressBar

### DIFF
--- a/app/src/components/ProgressBar.tsx
+++ b/app/src/components/ProgressBar.tsx
@@ -21,10 +21,15 @@ export default function ProgressBar({ progress, outlinedProgressBar }: ProgressB
           />
         </div>
       ) : (
-        <div className="mb-4 h-2 rounded-full border border-turtle-secondary bg-white">
+        <div
+          className={cn(
+            'mb-4 h-2 rounded-full border border-turtle-secondary bg-white',
+            progress <= 0 && 'animate-pulse',
+          )}
+        >
           {progress > 0 && (
             <div
-              className="-ml-[1px] -mt-[1px] h-2 rounded-full border border-turtle-secondary-dark bg-turtle-secondary"
+              className="-ml-[1px] -mt-[1px] h-2 rounded-full border border-turtle-secondary-dark bg-turtle-secondary transition-all duration-1000 ease-in-out"
               style={{ width: `${progress}%` }}
             />
           )}


### PR DESCRIPTION
While working on https://github.com/velocitylabs-org/turtle/pull/332, I noticed an improvement in the `ProgressBar` component. When the `outlinedProgressBar` prop was set to true, the animation (the width transition effect) was not functioning. This fix resolves that issue.