### PR TITLE
Conditional dividers in UI and wait for destination token

### DIFF
--- a/app/src/components/ChainTokenSelect.tsx
+++ b/app/src/components/ChainTokenSelect.tsx
@@ -49,6 +49,7 @@ interface ChainTokenSelectProps {
     sourceChainToDetermineOriginBanner: Chain | null
     error?: string
     clearable?: boolean
+    showVerticalDivider?: boolean
     orderBySelected?: boolean
     /** The token displayed at the top or below the selected token in the dropdown. Can be used to make it easier to select the source token again. */
     priorityToken?: Token | null
@@ -230,6 +231,7 @@ interface TokenAmountInputProps {
   token: {
     value: Token | null
     sourceChainToDetermineOriginBanner: Chain | null
+    showVerticalDivider?: boolean
   }
   amount?: {
     value: number | null
@@ -285,7 +287,7 @@ const TokenAmountInput = ({
             )}
           </div>
           <ChevronDown strokeWidth={0.2} className="ml-1" />
-          <VerticalDivider />
+          {token.showVerticalDivider && <VerticalDivider />}
           <div className="align-center ml-1 flex flex-col">
             <input
               data-cy="amount-input"

--- a/app/src/components/ChainTokenSelect.tsx
+++ b/app/src/components/ChainTokenSelect.tsx
@@ -253,6 +253,8 @@ const TokenAmountInput = ({
   triggerRef,
   inDollars,
 }: TokenAmountInputProps) => {
+  const showVerticalDivider = !!amount?.value || !!amount?.placeholder
+
   return (
     <Tooltip content={amount?.error}>
       <div
@@ -285,7 +287,7 @@ const TokenAmountInput = ({
             )}
           </div>
           <ChevronDown strokeWidth={0.2} className="ml-1" />
-          {!amount?.disabled && <VerticalDivider />}
+          {showVerticalDivider && <VerticalDivider />}
           <div className="align-center ml-1 flex flex-col">
             <input
               data-cy="amount-input"

--- a/app/src/components/ChainTokenSelect.tsx
+++ b/app/src/components/ChainTokenSelect.tsx
@@ -49,7 +49,6 @@ interface ChainTokenSelectProps {
     sourceChainToDetermineOriginBanner: Chain | null
     error?: string
     clearable?: boolean
-    showVerticalDivider?: boolean
     orderBySelected?: boolean
     /** The token displayed at the top or below the selected token in the dropdown. Can be used to make it easier to select the source token again. */
     priorityToken?: Token | null
@@ -231,7 +230,6 @@ interface TokenAmountInputProps {
   token: {
     value: Token | null
     sourceChainToDetermineOriginBanner: Chain | null
-    showVerticalDivider?: boolean
   }
   amount?: {
     value: number | null
@@ -287,7 +285,7 @@ const TokenAmountInput = ({
             )}
           </div>
           <ChevronDown strokeWidth={0.2} className="ml-1" />
-          {token.showVerticalDivider && <VerticalDivider />}
+          {!amount?.disabled && <VerticalDivider />}
           <div className="align-center ml-1 flex flex-col">
             <input
               data-cy="amount-input"

--- a/app/src/components/ChainTokenSelect.tsx
+++ b/app/src/components/ChainTokenSelect.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/utils/cn'
 import { reorderOptionsBySelectedItem } from '@/utils/sort'
 import NumberFlow from '@number-flow/react'
 import Image from 'next/image'
-import { ReactNode, RefObject, useMemo, useRef, useState } from 'react'
+import { ChangeEvent, ReactNode, RefObject, useMemo, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { normalize } from 'viem/ens'
 import { useEnsAvatar } from 'wagmi'
@@ -253,12 +253,11 @@ const TokenAmountInput = ({
   triggerRef,
   inDollars,
 }: TokenAmountInputProps) => {
-  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const showVerticalDivider = !!amount?.value || !!amount?.placeholder
+  const handleAmountChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newVal = e.target.value === '' ? null : parseFloat(e.target.value)
     amount?.onChange?.(newVal)
   }
-
-  const showVerticalDivider = !!amount?.value || !!amount?.placeholder
 
   return (
     <Tooltip content={amount?.error}>

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -190,7 +190,7 @@ export default function Transfer() {
 
   const sourceTokenOptions = useMemo(
     () => getAllowedSourceTokens(sourceChain, destinationChain),
-    [sourceChain],
+    [sourceChain, destinationChain],
   )
 
   const destinationTokenOptions = useMemo(
@@ -249,6 +249,7 @@ export default function Transfer() {
                         error: errors.sourceTokenAmount?.token?.message,
                         clearable: true,
                         orderBySelected: true,
+                        showVerticalDivider: true,
                       }}
                       amount={{
                         value: tokenField.value?.amount ?? null,
@@ -315,6 +316,7 @@ export default function Transfer() {
                       orderBySelected: true,
                       sourceChainToDetermineOriginBanner: sourceChain,
                       priorityToken: sourceTokenAmount?.token,
+                      showVerticalDivider: false,
                     }}
                     amount={{
                       value: destinationTokenAmount?.amount ?? null,

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -146,7 +146,7 @@ export default function Transfer() {
   else if (balanceData?.value === 0n) amountPlaceholder = 'No balance'
   else amountPlaceholder = formatAmount(Number(balanceData?.formatted), 'Longer')
 
-  let receiveAmountPlaceholder = 'Receive Token'
+  let receiveAmountPlaceholder = 'Receive Amount'
   if (isLoadingOutputAmount) receiveAmountPlaceholder = 'Loading...'
   else if (sourceTokenAmount?.token?.id === destinationTokenAmount?.token?.id)
     receiveAmountPlaceholder = ''

--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -146,7 +146,7 @@ export default function Transfer() {
   else if (balanceData?.value === 0n) amountPlaceholder = 'No balance'
   else amountPlaceholder = formatAmount(Number(balanceData?.formatted), 'Longer')
 
-  let receiveAmountPlaceholder = 'Receive Amount'
+  let receiveAmountPlaceholder = 'Receive Token'
   if (isLoadingOutputAmount) receiveAmountPlaceholder = 'Loading...'
   else if (sourceTokenAmount?.token?.id === destinationTokenAmount?.token?.id)
     receiveAmountPlaceholder = ''
@@ -249,7 +249,6 @@ export default function Transfer() {
                         error: errors.sourceTokenAmount?.token?.message,
                         clearable: true,
                         orderBySelected: true,
-                        showVerticalDivider: true,
                       }}
                       amount={{
                         value: tokenField.value?.amount ?? null,
@@ -316,7 +315,6 @@ export default function Transfer() {
                       orderBySelected: true,
                       sourceChainToDetermineOriginBanner: sourceChain,
                       priorityToken: sourceTokenAmount?.token,
-                      showVerticalDivider: false,
                     }}
                     amount={{
                       value: destinationTokenAmount?.amount ?? null,

--- a/app/src/hooks/useFees.ts
+++ b/app/src/hooks/useFees.ts
@@ -30,6 +30,7 @@ const useFees = (
   amount?: number | null,
   senderAddress?: string,
   recipientAddress?: string,
+  destToken?: Token | null,
 ) => {
   const [fees, setFees] = useState<AmountInfo | null>(null)
   const [bridgingFee, setBridgingFees] = useState<AmountInfo | null>(null)
@@ -54,7 +55,7 @@ const useFees = (
   })
 
   const fetchFees = useCallback(async () => {
-    if (!sourceChain || !destinationChain || !token) {
+    if (!sourceChain || !destinationChain || !token || !destToken) {
       setFees(null)
       setBridgingFees(null)
       return
@@ -208,6 +209,7 @@ const useFees = (
     amount,
     dotBalance,
     feeBalance,
+    destToken,
   ])
 
   useEffect(() => {

--- a/app/src/hooks/useTransferForm.ts
+++ b/app/src/hooks/useTransferForm.ts
@@ -86,6 +86,7 @@ const useTransferForm = () => {
     sourceTokenAmount?.amount,
     sourceWallet?.sender?.address,
     getRecipientAddress(manualRecipient, destinationWallet),
+    destToken,
   )
 
   const {


### PR DESCRIPTION
I was going through the new swap UI and noticed a couple of things:

1. We’re currently showing the divider for the destination token, even though at that point we’re just displaying the token itself and not any amount. This initially made me think that a value (like the amount I’d receive) was going to appear there. Since nothing actually shows up, I think it might be better to remove the divider for the destination token to avoid any confusion.
2. I also noticed that the fee UI appears even before a destination token is selected. This can make the UI feel a bit off and harder to understand, especially when the token selection menu is still open. I think it would be a smoother experience if we waited for the destination token to be selected before showing the fee-related info.

Let me know what you think.


<p align="center">
  <img src="https://github.com/user-attachments/assets/f3ac4cb2-cfd4-4dd0-9181-6cc3720757c8" width="350" />
  <img src="https://github.com/user-attachments/assets/bb619cf8-b8a6-4848-b666-45ca0beee403" width="350" />
</p>

**Note:**
It should be safe to merge into `feat/swaps-mvp`, even with the failing unit test. We’re already aware of the issue, and it’s also happening on that branch. If everything else looks good, we could consider force-merging it.