### PR TITLE
Fix failing unit test

### DIFF
--- a/app/jest.config.ts
+++ b/app/jest.config.ts
@@ -8,7 +8,7 @@ const createJestConfig = nextJest({
 
 const config: Config = {
   coverageProvider: 'v8',
-  testEnvironment: 'jest-environment-jsdom',
+  testEnvironment: 'jsdom',
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {

--- a/app/jest.config.ts
+++ b/app/jest.config.ts
@@ -6,13 +6,14 @@ const createJestConfig = nextJest({
   dir: './',
 })
 
-// Add any custom config to be passed to Jest
 const config: Config = {
   coverageProvider: 'v8',
-  testEnvironment: 'jsdom',
+  testEnvironment: 'jest-environment-jsdom',
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@paraspell/xcm-router$': '<rootDir>/node_modules/@paraspell/xcm-router/dist/index.d.ts',
+  },
 }
 
-// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
 export default createJestConfig(config)

--- a/app/jest.setup.ts
+++ b/app/jest.setup.ts
@@ -1,3 +1,5 @@
+import '@testing-library/jest-dom'
+
 import { TextDecoder, TextEncoder } from 'util' // Node.js util module
 
 global.TextEncoder = TextEncoder

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --transformIgnorePatterns \"node_modules/(?!@toolz/allow)/\" --debug",
+    "test": "jest --transformIgnorePatterns \"node_modules/(?!@toolz/allow)/\"",
     "test:watch": "jest --watch",
     "format": "prettier --write .",
     "format-check": "prettier --check .",

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --transformIgnorePatterns \"node_modules/(?!@toolz/allow)/\" --env=jsdom",
+    "test": "jest --transformIgnorePatterns \"node_modules/(?!@toolz/allow)/\" --debug",
     "test:watch": "jest --watch",
     "format": "prettier --write .",
     "format-check": "prettier --check .",

--- a/app/src/__tests__/Transfer.test.tsx
+++ b/app/src/__tests__/Transfer.test.tsx
@@ -4,7 +4,6 @@ import { EthereumTokens } from '@/registry/mainnet/tokens'
 import { Direction, resolveDirection } from '@/services/transfer'
 import { convertAmount, safeConvertAmount, toHuman } from '@/utils/transfer'
 import { describe, expect, it } from '@jest/globals'
-import '@testing-library/jest-dom'
 
 describe('Transfer', () => {
   it('direction ToEthereum', () => {

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
There was a failing test with the following error: 

```
Cannot find module '@paraspell/xcm-router' from 'src/utils/paraspellSwap.ts'
```

Apparently the compiler was failing to map the module for some reason. Mapping the module seems to fix the error, but it's still unknown why it wouldn't be mapped in the first place, maybe there's a mistake in the `@paraspell/xcm-router` `package.json`