### PR TITLE
fix: remove sentry capture

### DIFF
--- a/app/src/utils/token.ts
+++ b/app/src/utils/token.ts
@@ -1,21 +1,14 @@
 import { Token } from '@/models/token'
 import { REGISTRY } from '@/registry/mainnet/mainnet'
 import { deepEqual, TMultiLocation } from '@paraspell/sdk'
-import { captureException } from '@sentry/nextjs'
 
 export function getCoingekoId(token: Token): string {
   return token.coingeckoId ?? token.name.toLocaleLowerCase().replaceAll(' ', '-')
 }
 
 export function getTokenByMultilocation(multilocation: TMultiLocation): Token | undefined {
+  // If turtle doesn't support the token it won't be found
   const token = REGISTRY.tokens.find(token => deepEqual(token.multilocation, multilocation))
-
-  // Usually a token should be found, so log a warning if not
-  if (!token)
-    captureException(new Error('Token not found by multilocation'), {
-      level: 'warning',
-      extra: { multilocation },
-    })
 
   return token
 }


### PR DESCRIPTION
Removes sentry capture if a token is not found via multilocation. Which means we do not support it via our registry.