### PR TITLE
fix: wrong origin chain banner

### DIFF
--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -313,7 +313,7 @@ export default function Transfer() {
                       error: errors.destinationTokenAmount?.token?.message,
                       clearable: true,
                       orderBySelected: true,
-                      sourceChainToDetermineOriginBanner: sourceChain,
+                      sourceChainToDetermineOriginBanner: destinationChain,
                       priorityToken: sourceTokenAmount?.token,
                     }}
                     amount={{


### PR DESCRIPTION
This small PR fixes the issue of showing a wrong origin banner on a swap

![image](https://github.com/user-attachments/assets/95da8fc7-5424-4244-b3c0-978c53ec3b77)
