### PR TITLE
Enhance responsive styling for full-width components

### DIFF
--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -195,7 +195,7 @@ export default function Transfer() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="z-20 flex flex-col gap-1 rounded-3xl border-1 border-turtle-foreground bg-white p-5 px-[1.5rem] py-[2rem] sm:w-[31.5rem] sm:p-[2.5rem]"
+      className="z-20 flex w-[100vw] max-w-[90vw] flex-col gap-1 rounded-3xl border-1 border-turtle-foreground bg-white p-5 px-[1.5rem] py-[2rem] sm:w-[31.5rem] sm:p-[2.5rem]"
     >
       <div className="flex flex-col gap-5">
         {/* Source Chain */}

--- a/app/src/components/completed/TransactionHistory.tsx
+++ b/app/src/components/completed/TransactionHistory.tsx
@@ -12,7 +12,7 @@ export default function TransactionHistory({ transfers }: TransactionHistoryProp
   const formattedTransfers = formatTransfersByDate(transfers)
 
   return (
-    <div className="z-20 mb-12 flex max-h-[70vh] max-w-[90vw] flex-col gap-4 overflow-auto rounded-3xl border-1 border-turtle-foreground bg-white px-[1.5rem] py-[2rem] sm:w-[31.5rem] sm:p-[2.5rem]">
+    <div className="z-20 mb-12 flex max-h-[70vh] w-[100vw] max-w-[90vw] flex-col gap-4 overflow-auto rounded-3xl border-1 border-turtle-foreground bg-white px-[1.5rem] py-[2rem] sm:w-[31.5rem] sm:p-[2.5rem]">
       {formattedTransfers.map(({ date, transfers }, idx) => (
         <div key={idx + date + transfers.length}>
           <div className="w-full space-y-3">

--- a/app/src/components/completed/TransactionLoaderSkeleton.tsx
+++ b/app/src/components/completed/TransactionLoaderSkeleton.tsx
@@ -56,7 +56,7 @@ function SkeletonCard() {
 
 export default function TransactionLoaderSkeleton() {
   return (
-    <div className="z-20 mb-12 flex max-w-[90vw] flex-col gap-4 rounded-3xl bg-white p-4 px-[1.5rem] py-[2rem] sm:w-[31.5rem] sm:p-[2.5rem]">
+    <div className="z-20 mb-12 flex w-[100vw] max-w-[90vw] flex-col gap-4 rounded-3xl bg-white p-4 px-[1.5rem] py-[2rem] sm:w-[31.5rem] sm:p-[2.5rem]">
       {Array.from({ length: 2 }, (_, i) => i + 1).map(idx => (
         <div key={idx} className="z-30">
           <div className="w-full space-y-4">


### PR DESCRIPTION
On mobile viewports between roughly 425 px and 600 px wide, switching from the “New” tab to the “Done” tab causes the app’s main container to shrink. This sudden width change makes the UI feel jumpy and cramped, especially in the “Done” view. This PR fix that.
