### PR TITLE
Fix UX when changing source chain/token with a manual recipient set

### DIFF
--- a/app/src/components/ChainTrigger.tsx
+++ b/app/src/components/ChainTrigger.tsx
@@ -78,7 +78,7 @@ export default function ChainTrigger({
       >
         <div className="flex h-[3.5rem] flex-grow items-center gap-1">
           <div
-            className={cn('flex items-center gap-1 shrink-0', !disabled && 'cursor-pointer')}
+            className={cn('flex shrink-0 items-center gap-1', !disabled && 'cursor-pointer')}
             onClick={handleClick}
           >
             {value ? (
@@ -91,7 +91,7 @@ export default function ChainTrigger({
                   className="h-[2rem] w-[2rem] rounded-full border-1 border-turtle-foreground bg-background"
                 />
                 {shouldShowChainName && (
-                  <span className="text-nowrap ml-1" data-cy="chain-select-value">
+                  <span className="ml-1 text-nowrap" data-cy="chain-select-value">
                     {value.name}
                   </span>
                 )}
@@ -102,7 +102,14 @@ export default function ChainTrigger({
                 <span>Chain</span>
               </>
             )}
-            {(!manualRecipientInput?.enabled || manualRecipientInput?.address) && <ChevronDown strokeWidth={0.2} height={6} width={14} className="ml-1.5 mr-1 shrink-0" />}
+            {(!manualRecipientInput?.enabled || manualRecipientInput?.address) && (
+              <ChevronDown
+                strokeWidth={0.2}
+                height={6}
+                width={14}
+                className="ml-1.5 mr-1 shrink-0"
+              />
+            )}
           </div>
 
           {ensAvatar && (
@@ -120,9 +127,9 @@ export default function ChainTrigger({
           )}
 
           {/* Manual Address Input */}
-          { manualRecipientInput?.enabled && (
+          {manualRecipientInput?.enabled && (
             <>
-              { !manualRecipientInput.address && <VerticalDivider className='ml-1.5 mr-1' />}
+              {!manualRecipientInput.address && <VerticalDivider className="ml-1.5 mr-1" />}
               <input
                 type="text"
                 className={cn(

--- a/app/src/components/ChainTrigger.tsx
+++ b/app/src/components/ChainTrigger.tsx
@@ -78,7 +78,7 @@ export default function ChainTrigger({
       >
         <div className="flex h-[3.5rem] flex-grow items-center gap-1">
           <div
-            className={cn('flex items-center gap-1', !disabled && 'cursor-pointer')}
+            className={cn('flex items-center gap-1 shrink-0', !disabled && 'cursor-pointer')}
             onClick={handleClick}
           >
             {value ? (
@@ -91,7 +91,7 @@ export default function ChainTrigger({
                   className="h-[2rem] w-[2rem] rounded-full border-1 border-turtle-foreground bg-background"
                 />
                 {shouldShowChainName && (
-                  <span className="text-nowrap" data-cy="chain-select-value">
+                  <span className="text-nowrap ml-1" data-cy="chain-select-value">
                     {value.name}
                   </span>
                 )}
@@ -102,7 +102,7 @@ export default function ChainTrigger({
                 <span>Chain</span>
               </>
             )}
-            <ChevronDown strokeWidth={0.2} height={6} width={14} className="ml-1" />
+            {(!manualRecipientInput?.enabled || manualRecipientInput?.address) && <ChevronDown strokeWidth={0.2} height={6} width={14} className="ml-1.5 mr-1 shrink-0" />}
           </div>
 
           {ensAvatar && (
@@ -120,13 +120,13 @@ export default function ChainTrigger({
           )}
 
           {/* Manual Address Input */}
-          {manualRecipientInput?.enabled && (
+          { manualRecipientInput?.enabled && (
             <>
-              <VerticalDivider className={manualRecipientInput.address ? 'invisible' : 'visible'} />
+              { !manualRecipientInput.address && <VerticalDivider className='ml-1.5 mr-1' />}
               <input
                 type="text"
                 className={cn(
-                  'ml-1 h-[70%] w-full bg-transparent focus:border-0 focus:outline-none',
+                  'ml-0 h-[70%] w-full bg-transparent focus:border-0 focus:outline-none',
                   error && 'text-turtle-error',
                 )}
                 placeholder="Address"

--- a/app/src/components/VerticalDivider.tsx
+++ b/app/src/components/VerticalDivider.tsx
@@ -5,5 +5,7 @@ interface VerticalDividerProps {
 }
 
 export default function VerticalDivider({ className }: VerticalDividerProps) {
-  return <div className={cn('ml-2 h-[1.625rem] border-1 border-turtle-level2 rounded-lg', className)} />
+  return (
+    <div className={cn('ml-2 h-[1.625rem] rounded-lg border-1 border-turtle-level2', className)} />
+  )
 }

--- a/app/src/components/VerticalDivider.tsx
+++ b/app/src/components/VerticalDivider.tsx
@@ -5,5 +5,5 @@ interface VerticalDividerProps {
 }
 
 export default function VerticalDivider({ className }: VerticalDividerProps) {
-  return <div className={cn('ml-2 h-[1.625rem] border-1 border-turtle-level3', className)} />
+  return <div className={cn('ml-2 h-[1.625rem] border-1 border-turtle-level2 rounded-lg', className)} />
 }

--- a/app/src/hooks/useTransferForm.ts
+++ b/app/src/hooks/useTransferForm.ts
@@ -190,7 +190,7 @@ const useTransferForm = () => {
       // Reset destination and token only if the conditions above are not met
       setValue('sourceChain', newValue)
       setValue('destinationChain', null)
-      setValue('manualRecipient', { enabled: false, address: ''})
+      setValue('manualRecipient', { enabled: false, address: '' })
       setValue('sourceTokenAmount', { token: null, amount: null })
     },
     [setValue, sourceChain, destinationChain, sourceTokenAmount],
@@ -200,7 +200,7 @@ const useTransferForm = () => {
     async (newValue: Token | null) => {
       setValue('sourceTokenAmount', { token: newValue, amount: null })
       setValue('destinationChain', null)
-      setValue('manualRecipient', { enabled: false, address: ''})
+      setValue('manualRecipient', { enabled: false, address: '' })
       setValue('destinationTokenAmount', { token: null, amount: null })
     },
     [setValue],

--- a/app/src/hooks/useTransferForm.ts
+++ b/app/src/hooks/useTransferForm.ts
@@ -190,6 +190,7 @@ const useTransferForm = () => {
       // Reset destination and token only if the conditions above are not met
       setValue('sourceChain', newValue)
       setValue('destinationChain', null)
+      setValue('manualRecipient', { enabled: false, address: ''})
       setValue('sourceTokenAmount', { token: null, amount: null })
     },
     [setValue, sourceChain, destinationChain, sourceTokenAmount],
@@ -199,6 +200,7 @@ const useTransferForm = () => {
     async (newValue: Token | null) => {
       setValue('sourceTokenAmount', { token: newValue, amount: null })
       setValue('destinationChain', null)
+      setValue('manualRecipient', { enabled: false, address: ''})
       setValue('destinationTokenAmount', { token: null, amount: null })
     },
     [setValue],


### PR DESCRIPTION
Fixes https://linear.app/velocitylabs/issue/VEL-393/bug-manual-recipient-issue-when-updating-a-source-token

## Changes

- [x] Fix & improve styling
- [x] Wipe manual recipient when changing source chain/token
   We can decide to keep it if the new source+dest chains are compatible but let's keep it simple for now

### Before

https://github.com/user-attachments/assets/276f0d02-46cb-46d9-a6a5-e6350434f4da

### After

https://github.com/user-attachments/assets/89f94fef-4f60-41ec-9ad4-49c96d029e3a

