### PR TITLE
Fix logos not showing in Ongoing and Completed transfers

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -54,7 +54,6 @@ const nextConfig = {
       },
     ],
   },
-  transpilePackages: ['@velocitylabs-org/turtle-ui', '@velocitylabs-org/turtle-registry'],
 }
 
 // Sentry is enabled only in production builds to ensure error tracking in the live environment.

--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
-import { withSentryConfig } from '@sentry/nextjs'
 import withBundleAnalyzer from '@next/bundle-analyzer'
+import { withSentryConfig } from '@sentry/nextjs'
 
 const isDevelopment = process.env.NODE_ENV === 'development'
 const vercelDomain = process.env.NEXT_PUBLIC_VERCEL_URL
@@ -54,6 +54,7 @@ const nextConfig = {
       },
     ],
   },
+  transpilePackages: ['@velocitylabs-org/turtle-ui', '@velocitylabs-org/turtle-registry'],
 }
 
 // Sentry is enabled only in production builds to ensure error tracking in the live environment.

--- a/app/src/components/completed/TransactionHistory.tsx
+++ b/app/src/components/completed/TransactionHistory.tsx
@@ -1,3 +1,4 @@
+import { Chain, MainnetRegistry, Token } from '@velocitylabs-org/turtle-registry'
 import { cn } from '@velocitylabs-org/turtle-ui'
 import { CompletedTransfer } from '@/models/transfer'
 import { formatCompletedTransferDate } from '@/utils/datetime'
@@ -19,9 +20,22 @@ export default function TransactionHistory({ transfers }: TransactionHistoryProp
             <p className={cn('tx-group-date mb-[-1] text-sm', idx !== 0 && 'mt-5')}>
               {formatCompletedTransferDate(date)}
             </p>
-            {transfers.reverse().map((tx, idx) => (
-              <TransactionDialog key={idx + tx.id + tx.sender} tx={tx} />
-            ))}
+            {transfers.reverse().map((tx, idx) => {
+              tx.sourceToken = MainnetRegistry.tokens.find(
+                token => token.id === tx.sourceToken.id,
+              ) as Token
+              tx.destinationToken = MainnetRegistry.tokens.find(
+                token => token.id === tx.destinationToken?.id,
+              ) as Token
+              tx.sourceChain = MainnetRegistry.chains.find(
+                chain => chain.uid === tx.sourceChain.uid,
+              ) as Chain
+              tx.destChain = MainnetRegistry.chains.find(
+                chain => chain.uid === tx.destChain.uid,
+              ) as Chain
+
+              return <TransactionDialog key={idx + tx.id + tx.sender} tx={tx} />
+            })}
           </div>
         </div>
       ))}

--- a/app/src/components/completed/TransactionHistory.tsx
+++ b/app/src/components/completed/TransactionHistory.tsx
@@ -1,4 +1,4 @@
-import { Chain, MainnetRegistry, Token } from '@velocitylabs-org/turtle-registry'
+import { Chain, chainsByUid, Token, tokensById } from '@velocitylabs-org/turtle-registry'
 import { cn } from '@velocitylabs-org/turtle-ui'
 import { CompletedTransfer } from '@/models/transfer'
 import { formatCompletedTransferDate } from '@/utils/datetime'
@@ -21,20 +21,15 @@ export default function TransactionHistory({ transfers }: TransactionHistoryProp
               {formatCompletedTransferDate(date)}
             </p>
             {transfers.reverse().map((tx, idx) => {
-              tx.sourceToken = MainnetRegistry.tokens.find(
-                token => token.id === tx.sourceToken.id,
-              ) as Token
-              tx.destinationToken = MainnetRegistry.tokens.find(
-                token => token.id === tx.destinationToken?.id,
-              ) as Token
-              tx.sourceChain = MainnetRegistry.chains.find(
-                chain => chain.uid === tx.sourceChain.uid,
-              ) as Chain
-              tx.destChain = MainnetRegistry.chains.find(
-                chain => chain.uid === tx.destChain.uid,
-              ) as Chain
+              const transfer = {
+                ...tx,
+                sourceToken: tokensById[tx.sourceToken.id] as Token,
+                destinationToken: tokensById[tx.destinationToken?.id as string] as Token,
+                sourceChain: chainsByUid[tx.sourceChain.uid] as Chain,
+                destChain: chainsByUid[tx.destChain.uid] as Chain,
+              }
 
-              return <TransactionDialog key={idx + tx.id + tx.sender} tx={tx} />
+              return <TransactionDialog key={idx + tx.id + tx.sender} tx={transfer} />
             })}
           </div>
         </div>

--- a/app/src/components/ongoing/OngoingTransfers.tsx
+++ b/app/src/components/ongoing/OngoingTransfers.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Token, MainnetRegistry, Chain } from '@velocitylabs-org/turtle-registry'
+import { Token, Chain, tokensById, chainsByUid } from '@velocitylabs-org/turtle-registry'
 import { Dispatch, SetStateAction } from 'react'
 import useOcelloidsSubscribe from '@/hooks/useOcelloidsSubscribe'
 import useOngoingTransfersCleaner from '@/hooks/useOngoingTransferCleaner'
@@ -38,22 +38,20 @@ export default function OngoingTransfers({
           </div>
           <div className="mt-8 flex w-full flex-col gap-2 rounded-[24px] border-1 border-turtle-foreground bg-white p-[2.5rem] px-[1.5rem] py-[2rem] sm:p-[2.5rem]">
             {ongoingTransfers.map(tx => {
-              tx.sourceToken = MainnetRegistry.tokens.find(
-                token => token.id === tx.sourceToken.id,
-              ) as Token
-              tx.destinationToken = MainnetRegistry.tokens.find(
-                token => token.id === tx.destinationToken?.id,
-              ) as Token
-
-              tx.sourceChain = MainnetRegistry.chains.find(
-                chain => chain.uid === tx.sourceChain.uid,
-              ) as Chain
-              tx.destChain = MainnetRegistry.chains.find(
-                chain => chain.uid === tx.destChain.uid,
-              ) as Chain
+              const transfer = {
+                ...tx,
+                sourceToken: tokensById[tx.sourceToken.id] as Token,
+                destinationToken: tokensById[tx.destinationToken?.id as string] as Token,
+                sourceChain: chainsByUid[tx.sourceChain.uid] as Chain,
+                destChain: chainsByUid[tx.destChain.uid] as Chain,
+              }
 
               return (
-                <OngoingTransferDialog key={tx.id} transfer={tx} status={statusMessages[tx.id]} />
+                <OngoingTransferDialog
+                  key={tx.id}
+                  transfer={transfer}
+                  status={statusMessages[tx.id]}
+                />
               )
             })}
 

--- a/app/src/components/ongoing/OngoingTransfers.tsx
+++ b/app/src/components/ongoing/OngoingTransfers.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { Token, MainnetRegistry, Chain } from '@velocitylabs-org/turtle-registry'
 import { Dispatch, SetStateAction } from 'react'
 import useOcelloidsSubscribe from '@/hooks/useOcelloidsSubscribe'
 import useOngoingTransfersCleaner from '@/hooks/useOngoingTransferCleaner'
@@ -36,9 +37,25 @@ export default function OngoingTransfers({
             Ongoing
           </div>
           <div className="mt-8 flex w-full flex-col gap-2 rounded-[24px] border-1 border-turtle-foreground bg-white p-[2.5rem] px-[1.5rem] py-[2rem] sm:p-[2.5rem]">
-            {ongoingTransfers.map(tx => (
-              <OngoingTransferDialog key={tx.id} transfer={tx} status={statusMessages[tx.id]} />
-            ))}
+            {ongoingTransfers.map(tx => {
+              tx.sourceToken = MainnetRegistry.tokens.find(
+                token => token.id === tx.sourceToken.id,
+              ) as Token
+              tx.destinationToken = MainnetRegistry.tokens.find(
+                token => token.id === tx.destinationToken?.id,
+              ) as Token
+
+              tx.sourceChain = MainnetRegistry.chains.find(
+                chain => chain.uid === tx.sourceChain.uid,
+              ) as Chain
+              tx.destChain = MainnetRegistry.chains.find(
+                chain => chain.uid === tx.destChain.uid,
+              ) as Chain
+
+              return (
+                <OngoingTransferDialog key={tx.id} transfer={tx} status={statusMessages[tx.id]} />
+              )
+            })}
 
             {hasCompletedTransfers && (
               <button
@@ -46,7 +63,7 @@ export default function OngoingTransfers({
                 disabled={!hasCompletedTransfers}
                 className="flex w-full flex-row items-center justify-center rounded-[8px] border border-turtle-level3 py-[8px] text-center text-lg text-turtle-foreground"
               >
-                <span>View completed transactions</span>{' '}
+                <span>View completed transactions </span>
                 <ArrowRight
                   className="mx-2 h-[1.3rem] w-[1.3rem]"
                   fill={colors['turtle-foreground']}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -7,6 +7,6 @@
     },
     "types": ["jest"]
   },
-  "include": ["next-env.d.ts", "src", ".next/types/**/*.ts", ".eslintrc.js"],
+  "include": ["next-env.d.ts", "src", ".next/types/**/*.ts", ".eslintrc.js", "next.config.mjs"],
   "exclude": ["node_modules"]
 }

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -8,7 +8,7 @@ import {
   Moonbeam,
   Mythos,
 } from "./mainnet/chains";
-import { Environment, LocalAssetUid } from "./types";
+import { Chain, Environment, LocalAssetUid, Token } from "./types";
 
 const SNOWBRIDGE_MAINNET_PARACHAINS = [
   AssetHub,
@@ -22,6 +22,22 @@ const SNOWBRIDGE_MAINNET_PARACHAINS = [
 export const REGISTRY = {
   mainnet: MainnetRegistry,
 };
+
+export const tokensById = MainnetRegistry.tokens.reduce<Record<string, Token>>(
+  (acc, token) => {
+    acc[token.id] = token;
+    return acc;
+  },
+  {},
+);
+
+export const chainsByUid = MainnetRegistry.chains.reduce<Record<string, Chain>>(
+  (acc, chain) => {
+    acc[chain.uid] = chain;
+    return acc;
+  },
+  {},
+);
 
 export const SNOWBRIDGE_MAINNET_PARACHAIN_URLS = Object.fromEntries(
   SNOWBRIDGE_MAINNET_PARACHAINS.map((chain) => [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,8 +19,8 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
     }
   },
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,8 +19,8 @@
   ],
   "exports": {
     ".": {
-      "import": "./src/index.js",
-      "types": "./src/index.d.ts"
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,8 +19,8 @@
   ],
   "exports": {
     ".": {
-      "import": "./src/index.ts",
-      "types": "./src/index.ts"
+      "import": "./src/index.js",
+      "types": "./src/index.d.ts"
     }
   },
   "dependencies": {

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { ReactNode } from 'react'
 import { twMerge } from 'tailwind-merge'
-import { Sizes } from '@/types/global'
+import { Sizes } from '../types/global'
 import { LoadingIcon } from './LoadingIcon'
 
 export type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'update'

--- a/packages/ui/src/components/TokenLogo.tsx
+++ b/packages/ui/src/components/TokenLogo.tsx
@@ -22,7 +22,9 @@ export const TokenLogo = ({ token, sourceChain, size = 32, className }: TokenLog
   return (
     <Tooltip content={originBadge?.text ?? token.symbol} showIcon={false}>
       <div className={cn('relative flex items-center', className)}>
-        <Icon width={size} height={size} src={logoURI} className="border-turtle-foreground" />
+        {logoURI && (
+          <Icon width={size} height={size} src={logoURI} className="border-turtle-foreground" />
+        )}
         {originBadge && (
           <Icon
             width={size / 2}


### PR DESCRIPTION
The transfers are being saved with the entirety of the Chain and/or Token in the storage itself – this is an issue, especially for images that might change paths (like logoURI). Therefore now we map the Chain (or Token) to the registry where the most up-to-date information relies. 

It's not the ideal solution because I would like the mapping to happen on a higher level, but for the sake of being quick this is a good short term fix. I would need to investigare more on how the transfers are mapped in the first, but I feel it would be a potential breaking change rn which is out of scope.

