### PR TITLE
Feat: Add volume and transaction count graphs

### DIFF
--- a/analytics/src/app/actions/summary.ts
+++ b/analytics/src/app/actions/summary.ts
@@ -166,7 +166,7 @@ export async function getSummaryData() {
       recentTransactions: serializedRecentTransactions,
       topTokensByVolume,
       topTokensByCount,
-      monthlyTransByVolumeAndCount
+      monthlyTransByVolumeAndCount,
     }
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e))

--- a/analytics/src/app/actions/summary.ts
+++ b/analytics/src/app/actions/summary.ts
@@ -13,8 +13,9 @@ export async function getSummaryData() {
       totalTransactions,
       successfulTransactions,
       recentTransactions,
-      topTokensResult,
-      dailyVolumeResult,
+      topTokensByVolume,
+      topTokensByCount,
+      monthlyTransByVolumeAndCount,
     ] = await Promise.all([
       // Total volume in USD
       Transaction.aggregate([
@@ -68,11 +69,10 @@ export async function getSummaryData() {
             _id: '$sourceTokenId', // Group only by sourceTokenId
             symbol: { $first: '$sourceTokenSymbol' },
             name: { $first: '$sourceTokenName' },
-            volumeUsd: { $sum: '$sourceTokenAmountUsd' },
-            count: { $sum: 1 },
+            volume: { $sum: '$sourceTokenAmountUsd' },
           },
         },
-        { $sort: { volumeUsd: -1 } },
+        { $sort: { volume: -1 } },
         { $limit: 2 },
         {
           $project: {
@@ -80,13 +80,40 @@ export async function getSummaryData() {
             id: '$_id',
             symbol: 1,
             name: 1,
-            volumeUsd: 1,
+            volume: 1,
+          },
+        },
+      ]),
+
+      // Top 2 tokens by transaction count
+      Transaction.aggregate([
+        {
+          $match: {
+            status: 'succeeded',
+          },
+        },
+        {
+          $group: {
+            _id: '$sourceTokenId', // Group only by sourceTokenId
+            symbol: { $first: '$sourceTokenSymbol' },
+            name: { $first: '$sourceTokenName' },
+            count: { $sum: 1 },
+          },
+        },
+        { $sort: { count: -1 } },
+        { $limit: 2 },
+        {
+          $project: {
+            _id: 0,
+            id: '$_id',
+            symbol: 1,
+            name: 1,
             count: 1,
           },
         },
       ]),
 
-      // Monthly volume for the last 6 months
+      // Monthly trans by volume and transaction count, for the last 6 months
       Transaction.aggregate([
         {
           $match: {
@@ -137,8 +164,9 @@ export async function getSummaryData() {
       avgTransactionValue,
       successRate,
       recentTransactions: serializedRecentTransactions,
-      topTokens: topTokensResult,
-      dailyVolume: dailyVolumeResult,
+      topTokensByVolume,
+      topTokensByCount,
+      monthlyTransByVolumeAndCount
     }
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e))

--- a/analytics/src/app/page.tsx
+++ b/analytics/src/app/page.tsx
@@ -1,17 +1,23 @@
 'use client'
 import { useQuery } from '@tanstack/react-query'
 import { CircleCheckBig, DollarSign, Repeat, Activity } from 'lucide-react'
+import {useState} from "react";
 import { getSummaryData } from '@/app/actions/summary'
 import ErrorPanel from '@/components/ErrorPanel'
 import RecentTransactionsTable from '@/components/RecentTransactionsTable'
 import SmallStatBox from '@/components/SmallStatBox'
+import TitleToggle from "@/components/TitleToggle";
 import TopTokensChart from '@/components/TopTokensChart'
 import TransactionVolumeChart from '@/components/TransactionVolumeChart'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import useShowLoadingBar from '@/hooks/useShowLoadingBar'
 import formatUSD from '@/utils/format-USD'
 
+type GraphType = "volume" | "transactions"
+
 export default function HomeDashboardPage() {
+  const [transactionGraphType, setTransactionGraphType] = useState<GraphType>("volume")
+  const [tokensGraphType, setTokensGraphType] = useState<GraphType>("volume")
   const { data, isLoading, error } = useQuery({
     queryKey: ['summary'],
     queryFn: getSummaryData,
@@ -70,8 +76,21 @@ export default function HomeDashboardPage() {
       <div className="mt-4 grid gap-4 lg:grid-cols-7">
         <Card className="col-span-full lg:col-span-4">
           <CardHeader>
-            <CardTitle>Transaction Volume</CardTitle>
-            <CardDescription>Over the last 6 months (USD)</CardDescription>
+            <div>
+            <CardTitle>
+              Transactions by
+              <TitleToggle
+                options={[
+                  { value: "volume", label: "Volume" },
+                  { value: "transactions", label: "Number" },
+                ]}
+                value={transactionGraphType}
+                onChange={(value) => setTransactionGraphType(value as GraphType)}
+                className="ml-3"
+              />
+            </CardTitle>
+            <CardDescription>Over the last 6 months</CardDescription>
+            </div>
           </CardHeader>
           <CardContent className="px-4">
             {isLoading ? (
@@ -85,8 +104,19 @@ export default function HomeDashboardPage() {
         </Card>
         <Card className="col-span-full lg:col-span-3">
           <CardHeader>
-            <CardTitle>Top Tokens</CardTitle>
-            <CardDescription>With highest successful transaction volume (USD)</CardDescription>
+            <CardTitle>
+              Top tokens by
+              <TitleToggle
+                options={[
+                  { value: "volume", label: "Volume" },
+                  { value: "transactions", label: "Number" },
+                ]}
+                value={tokensGraphType}
+                onChange={(value) => setTokensGraphType(value as GraphType)}
+                className="ml-3"
+              />
+            </CardTitle>
+            <CardDescription>With highest successful transaction</CardDescription>
           </CardHeader>
           <CardContent>
             {isLoading ? (

--- a/analytics/src/app/page.tsx
+++ b/analytics/src/app/page.tsx
@@ -8,7 +8,7 @@ import RecentTransactionsTable from '@/components/RecentTransactionsTable'
 import SmallStatBox from '@/components/SmallStatBox'
 import TitleToggle from "@/components/TitleToggle";
 import TopTokensChart from '@/components/TopTokensChart'
-import TransactionVolumeChart from '@/components/TransactionVolumeChart'
+import TransactionChart from '@/components/TransactionChart'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import useShowLoadingBar from '@/hooks/useShowLoadingBar'
 import formatUSD from '@/utils/format-USD'
@@ -34,6 +34,9 @@ export default function HomeDashboardPage() {
     avgTransactionValue: 0,
     successRate: 0,
   }
+
+  console.log('data', data)
+
 
   return (
     <div>
@@ -98,7 +101,7 @@ export default function HomeDashboardPage() {
                 <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary"></div>
               </div>
             ) : (
-              <TransactionVolumeChart data={data?.dailyVolume || []} />
+              <TransactionChart data={data?.monthlyTransByVolumeAndCount || []} type={transactionGraphType} />
             )}
           </CardContent>
         </Card>
@@ -125,8 +128,9 @@ export default function HomeDashboardPage() {
               </div>
             ) : (
               <TopTokensChart
-                data={data?.topTokens || []}
-                totalVolume={data?.totalVolumeUsd || 0}
+                data={tokensGraphType === 'volume'? data?.topTokensByVolume : data?.topTokensByCount || []}
+                total={tokensGraphType === 'volume'? data?.totalVolumeUsd : data?.totalTransactions}
+                type={tokensGraphType}
               />
             )}
           </CardContent>

--- a/analytics/src/app/page.tsx
+++ b/analytics/src/app/page.tsx
@@ -128,7 +128,7 @@ export default function HomeDashboardPage() {
               </div>
             ) : (
               <TopTokensChart
-                data={tokensGraphType === 'volume'? data?.topTokensByVolume : data?.topTokensByCount || []}
+                data={tokensGraphType === 'volume'? data?.topTokensByVolume : data?.topTokensByCount}
                 total={tokensGraphType === 'volume'? data?.totalVolumeUsd : data?.totalTransactions}
                 type={tokensGraphType}
               />

--- a/analytics/src/app/page.tsx
+++ b/analytics/src/app/page.tsx
@@ -1,23 +1,23 @@
 'use client'
 import { useQuery } from '@tanstack/react-query'
 import { CircleCheckBig, DollarSign, Repeat, Activity } from 'lucide-react'
-import {useState} from "react";
+import { useState } from 'react'
 import { getSummaryData } from '@/app/actions/summary'
 import ErrorPanel from '@/components/ErrorPanel'
 import RecentTransactionsTable from '@/components/RecentTransactionsTable'
 import SmallStatBox from '@/components/SmallStatBox'
-import TitleToggle from "@/components/TitleToggle";
+import TitleToggle from '@/components/TitleToggle'
 import TopTokensChart from '@/components/TopTokensChart'
 import TransactionChart from '@/components/TransactionChart'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import useShowLoadingBar from '@/hooks/useShowLoadingBar'
 import formatUSD from '@/utils/format-USD'
 
-type GraphType = "volume" | "transactions"
+type GraphType = 'volume' | 'transactions'
 
 export default function HomeDashboardPage() {
-  const [transactionGraphType, setTransactionGraphType] = useState<GraphType>("volume")
-  const [tokensGraphType, setTokensGraphType] = useState<GraphType>("volume")
+  const [transactionGraphType, setTransactionGraphType] = useState<GraphType>('volume')
+  const [tokensGraphType, setTokensGraphType] = useState<GraphType>('volume')
   const { data, isLoading, error } = useQuery({
     queryKey: ['summary'],
     queryFn: getSummaryData,
@@ -36,7 +36,6 @@ export default function HomeDashboardPage() {
   }
 
   console.log('data', data)
-
 
   return (
     <div>
@@ -80,19 +79,19 @@ export default function HomeDashboardPage() {
         <Card className="col-span-full lg:col-span-4">
           <CardHeader>
             <div>
-            <CardTitle>
-              Transactions by
-              <TitleToggle
-                options={[
-                  { value: "volume", label: "Volume" },
-                  { value: "transactions", label: "Number" },
-                ]}
-                value={transactionGraphType}
-                onChange={(value) => setTransactionGraphType(value as GraphType)}
-                className="ml-3"
-              />
-            </CardTitle>
-            <CardDescription>Over the last 6 months</CardDescription>
+              <CardTitle>
+                Transactions by
+                <TitleToggle
+                  options={[
+                    { value: 'volume', label: 'Volume' },
+                    { value: 'transactions', label: 'Number' },
+                  ]}
+                  value={transactionGraphType}
+                  onChange={value => setTransactionGraphType(value as GraphType)}
+                  className="ml-3"
+                />
+              </CardTitle>
+              <CardDescription>Over the last 6 months</CardDescription>
             </div>
           </CardHeader>
           <CardContent className="px-4">
@@ -101,7 +100,10 @@ export default function HomeDashboardPage() {
                 <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary"></div>
               </div>
             ) : (
-              <TransactionChart data={data?.monthlyTransByVolumeAndCount || []} type={transactionGraphType} />
+              <TransactionChart
+                data={data?.monthlyTransByVolumeAndCount || []}
+                type={transactionGraphType}
+              />
             )}
           </CardContent>
         </Card>
@@ -111,11 +113,11 @@ export default function HomeDashboardPage() {
               Top tokens by
               <TitleToggle
                 options={[
-                  { value: "volume", label: "Volume" },
-                  { value: "transactions", label: "Number" },
+                  { value: 'volume', label: 'Volume' },
+                  { value: 'transactions', label: 'Number' },
                 ]}
                 value={tokensGraphType}
-                onChange={(value) => setTokensGraphType(value as GraphType)}
+                onChange={value => setTokensGraphType(value as GraphType)}
                 className="ml-3"
               />
             </CardTitle>
@@ -128,8 +130,12 @@ export default function HomeDashboardPage() {
               </div>
             ) : (
               <TopTokensChart
-                data={tokensGraphType === 'volume'? data?.topTokensByVolume : data?.topTokensByCount}
-                total={tokensGraphType === 'volume'? data?.totalVolumeUsd : data?.totalTransactions}
+                data={
+                  tokensGraphType === 'volume' ? data?.topTokensByVolume : data?.topTokensByCount
+                }
+                total={
+                  tokensGraphType === 'volume' ? data?.totalVolumeUsd : data?.totalTransactions
+                }
                 type={tokensGraphType}
               />
             )}

--- a/analytics/src/components/TitleToggle.tsx
+++ b/analytics/src/components/TitleToggle.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { cn } from '@velocitylabs-org/turtle-ui'
+import { useState, useRef, useEffect } from "react"
+
+interface Option {
+  value: string
+  label: string
+}
+
+interface SegmentedControlProps {
+  options: Option[]
+  value?: string
+  defaultValue?: string
+  onChange: (value: string) => void
+  className?: string
+}
+
+export default function TitleToggle({ options, value, defaultValue, onChange, className }: SegmentedControlProps) {
+  const [internalValue, setInternalValue] = useState(value || defaultValue || options[0]?.value)
+  const [indicatorPosition, setIndicatorPosition] = useState({ width: 0, left: 0 })
+  const buttonsRef = useRef<(HTMLButtonElement | null)[]>([])
+
+  const currentValue = value !== undefined ? value : internalValue
+
+  useEffect(() => {
+    const activeIndex = options.findIndex((option) => option.value === currentValue)
+    const activeButton = buttonsRef.current[activeIndex]
+
+    if (activeButton) {
+      setIndicatorPosition({
+        width: activeButton.offsetWidth,
+        left: activeButton.offsetLeft,
+      })
+    }
+  }, [currentValue, options])
+
+  const handleClick = (optionValue: string) => {
+    if (value === undefined) {
+      setInternalValue(optionValue)
+    }
+    onChange(optionValue)
+  }
+
+  return (
+    <div className={cn(
+      "relative bg-gray-100 rounded-lg p-1 inline-flex",
+      className
+    )}>
+      <div
+        className="absolute top-1 bottom-1 bg-white rounded-md shadow-sm transition-all duration-200 ease-out"
+        style={{
+          width: indicatorPosition.width,
+          left: indicatorPosition.left,
+        }}
+      />
+      {options.map((option, index) => (
+        <button
+          key={option.value}
+          ref={(el) => {
+            buttonsRef.current[index] = el
+          }}
+          onClick={() => handleClick(option.value)}
+          className={cn(
+            "relative z-10 px-2 py-1 text-sm font-bold rounded-md transition-all duration-200",
+            currentValue === option.value
+              ? "text-gray-900"
+              : "text-gray-600 hover:text-gray-900"
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/analytics/src/components/TitleToggle.tsx
+++ b/analytics/src/components/TitleToggle.tsx
@@ -1,7 +1,7 @@
-"use client"
+'use client'
 
 import { cn } from '@velocitylabs-org/turtle-ui'
-import { useState, useRef, useEffect } from "react"
+import { useState, useRef, useEffect } from 'react'
 
 interface Option {
   value: string
@@ -16,7 +16,13 @@ interface SegmentedControlProps {
   className?: string
 }
 
-export default function TitleToggle({ options, value, defaultValue, onChange, className }: SegmentedControlProps) {
+export default function TitleToggle({
+  options,
+  value,
+  defaultValue,
+  onChange,
+  className,
+}: SegmentedControlProps) {
   const [internalValue, setInternalValue] = useState(value || defaultValue || options[0]?.value)
   const [indicatorPosition, setIndicatorPosition] = useState({ width: 0, left: 0 })
   const buttonsRef = useRef<(HTMLButtonElement | null)[]>([])
@@ -24,7 +30,7 @@ export default function TitleToggle({ options, value, defaultValue, onChange, cl
   const currentValue = value !== undefined ? value : internalValue
 
   useEffect(() => {
-    const activeIndex = options.findIndex((option) => option.value === currentValue)
+    const activeIndex = options.findIndex(option => option.value === currentValue)
     const activeButton = buttonsRef.current[activeIndex]
 
     if (activeButton) {
@@ -43,12 +49,9 @@ export default function TitleToggle({ options, value, defaultValue, onChange, cl
   }
 
   return (
-    <div className={cn(
-      "relative bg-gray-100 rounded-lg p-1 inline-flex",
-      className
-    )}>
+    <div className={cn('relative inline-flex rounded-lg bg-gray-100 p-1', className)}>
       <div
-        className="absolute top-1 bottom-1 bg-white rounded-md shadow-sm transition-all duration-200 ease-out"
+        className="absolute bottom-1 top-1 rounded-md bg-white shadow-sm transition-all duration-200 ease-out"
         style={{
           width: indicatorPosition.width,
           left: indicatorPosition.left,
@@ -57,15 +60,13 @@ export default function TitleToggle({ options, value, defaultValue, onChange, cl
       {options.map((option, index) => (
         <button
           key={option.value}
-          ref={(el) => {
+          ref={el => {
             buttonsRef.current[index] = el
           }}
           onClick={() => handleClick(option.value)}
           className={cn(
-            "relative z-10 px-2 py-1 text-sm font-bold rounded-md transition-all duration-200",
-            currentValue === option.value
-              ? "text-gray-900"
-              : "text-gray-600 hover:text-gray-900"
+            'relative z-10 rounded-md px-2 py-1 text-sm font-bold transition-all duration-200',
+            currentValue === option.value ? 'text-gray-900' : 'text-gray-600 hover:text-gray-900',
           )}
         >
           {option.label}

--- a/analytics/src/components/TokensActivityTable.tsx
+++ b/analytics/src/components/TokensActivityTable.tsx
@@ -129,7 +129,7 @@ function TokensTableContent({ tokens, isLoading }: TokensTableContentProps) {
     return (
       <TableRow key={0}>
         <TableCell colSpan={6} className="text-center">
-          <div className="flex h-[250px] items-center justify-center">
+          <div className="flex items-center justify-center" style={{ height: 'calc(100vh - 300px)' }}>
             <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary"></div>
           </div>
         </TableCell>
@@ -141,7 +141,7 @@ function TokensTableContent({ tokens, isLoading }: TokensTableContentProps) {
     return (
       <TableRow key={1}>
         <TableCell colSpan={6} className="text-center">
-          <div className="flex h-[250px] items-center justify-center">
+          <div className="flex items-center justify-center" style={{ height: 'calc(100vh - 300px)' }}>
             <p>There are no recent token activity to display</p>
           </div>
         </TableCell>

--- a/analytics/src/components/TokensActivityTable.tsx
+++ b/analytics/src/components/TokensActivityTable.tsx
@@ -129,7 +129,10 @@ function TokensTableContent({ tokens, isLoading }: TokensTableContentProps) {
     return (
       <TableRow key={0}>
         <TableCell colSpan={6} className="text-center">
-          <div className="flex items-center justify-center" style={{ height: 'calc(100vh - 300px)' }}>
+          <div
+            className="flex items-center justify-center"
+            style={{ height: 'calc(100vh - 300px)' }}
+          >
             <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary"></div>
           </div>
         </TableCell>
@@ -141,7 +144,10 @@ function TokensTableContent({ tokens, isLoading }: TokensTableContentProps) {
     return (
       <TableRow key={1}>
         <TableCell colSpan={6} className="text-center">
-          <div className="flex items-center justify-center" style={{ height: 'calc(100vh - 300px)' }}>
+          <div
+            className="flex items-center justify-center"
+            style={{ height: 'calc(100vh - 300px)' }}
+          >
             <p>There are no recent token activity to display</p>
           </div>
         </TableCell>

--- a/analytics/src/components/TopTokensChart.tsx
+++ b/analytics/src/components/TopTokensChart.tsx
@@ -69,11 +69,9 @@ const CustomTooltip = ({ active, payload, total, typeVolume }: CustomTooltip) =>
   return (
     <div className="min-w-[8rem] rounded-lg border bg-background p-2 text-xs shadow-xl">
       <span className="font-medium">{data.name} </span>
-      {data?.value && <span>
-        ({((data.value / total) * 100).toFixed(2)}%)
-      </span>}
+      {data?.value && <span>({((data.value / total) * 100).toFixed(2)}%)</span>}
       <p className="text-muted-foreground">
-        {typeVolume ? `${formatUSD(data?.value)}` : `${data?.value} transactions` }
+        {typeVolume ? `${formatUSD(data?.value)}` : `${data?.value} transactions`}
       </p>
       {token && <p className="text-[10px]">({token.origin.type})</p>}
     </div>
@@ -85,16 +83,14 @@ export default function TopTokensChart({ data = [], type, total = 0 }: TopTokens
   const isMobile = useIsMobile()
 
   const formattedData = data.map(item => {
-    const value = typeVolume 
-      ? (item.volume ?? 0)
-      : (item.count ?? 0);
+    const value = typeVolume ? (item.volume ?? 0) : (item.count ?? 0)
 
     return {
       name: item.symbol,
       value,
       percentage: (value / total) * 100,
       id: item.id,
-    };
+    }
   })
 
   // Calculate the sum of the displayed tokens
@@ -131,7 +127,7 @@ export default function TopTokensChart({ data = [], type, total = 0 }: TopTokens
               <Cell key={`cell-${index}`} fill={colors[index % colors.length]} />
             ))}
           </Pie>
-          <Tooltip content={<CustomTooltip total={total} typeVolume={typeVolume}/>} />
+          <Tooltip content={<CustomTooltip total={total} typeVolume={typeVolume} />} />
         </PieChart>
       </ResponsiveContainer>
     </div>

--- a/analytics/src/components/TopTokensChart.tsx
+++ b/analytics/src/components/TopTokensChart.tsx
@@ -14,9 +14,8 @@ const colors = [
 ]
 
 interface TopTokensChartProps {
-  data: { symbol: string; volume: number; id: string }[]
+  data?: { symbol: string; volume?: number; count?: number; id: string }[]
   total: number
-  totalCount: number
   type: 'volume' | 'transactions'
 }
 
@@ -81,16 +80,22 @@ const CustomTooltip = ({ active, payload, total, typeVolume }: CustomTooltip) =>
   )
 }
 
-export default function TopTokensChart({ data, type, total = 0 }: TopTokensChartProps) {
+export default function TopTokensChart({ data = [], type, total = 0 }: TopTokensChartProps) {
   const typeVolume = type === 'volume'
   const isMobile = useIsMobile()
 
-  const formattedData = data.map(item => ({
-    name: item.symbol,
-    value: typeVolume ? item.volume : item.count,
-    percentage: (( typeVolume ? item.volume : item.count) / total) * 100,
-    id: item.id,
-  }))
+  const formattedData = data.map(item => {
+    const value = typeVolume 
+      ? (item.volume ?? 0)
+      : (item.count ?? 0);
+
+    return {
+      name: item.symbol,
+      value,
+      percentage: (value / total) * 100,
+      id: item.id,
+    };
+  })
 
   // Calculate the sum of the displayed tokens
   const displayedValue = formattedData.reduce((sum, item) => sum + item.value, 0)

--- a/analytics/src/components/TransactionChart.tsx
+++ b/analytics/src/components/TransactionChart.tsx
@@ -15,11 +15,12 @@ import formatUSD from '@/utils/format-USD'
 
 const chartColor = primaryColor
 
-interface TransactionVolumeChartProps {
-  data: { month: string; volumeUsd: number }[]
+interface TransactionChartProps {
+  data: { month: string; volumeUsd: number; count: number }[]
+  type: 'volume' | 'transactions'
 }
 
-const CustomTooltip = ({ active, payload, label }: TooltipProps<number, string>) => {
+const CustomTooltip = ({ active, payload, label, type }: TooltipProps<number, string> & { type: 'volume' | 'transactions' }) => {
   if (!active || !payload || !payload.length) {
     return null
   }
@@ -27,15 +28,19 @@ const CustomTooltip = ({ active, payload, label }: TooltipProps<number, string>)
   return (
     <div className="min-w-[8rem] rounded-lg border bg-background p-2 text-xs shadow-xl">
       <p className="font-medium">{label}</p>
-      <p className="text-muted-foreground">${formatUSD(payload[0].value)}</p>
+      {type === 'volume' ? (
+        <p className="text-muted-foreground">${formatUSD(payload[0].value)}</p>
+      ) : (
+        <p className="text-muted-foreground">{payload[0].value} transactions</p>
+      )}
     </div>
   )
 }
 
-export default function TransactionVolumeChart({ data }: TransactionVolumeChartProps) {
+export default function TransactionChart({ data, type }: TransactionChartProps) {
   const formattedData = data.map(item => ({
     date: new Date(item.month).toLocaleDateString('en-US', { month: 'short' }),
-    volume: item.volumeUsd,
+    value: type === 'volume' ? item.volumeUsd : item.count,
   }))
 
   return (
@@ -50,16 +55,16 @@ export default function TransactionVolumeChart({ data }: TransactionVolumeChartP
           </defs>
           <XAxis dataKey="date" tickLine={false} axisLine={false} tickMargin={10} />
           <YAxis
-            tickFormatter={value => `$${(value / 1000).toFixed(0)}k`}
+            tickFormatter={value => type === 'volume' ? `$${(value / 1000).toFixed(0)}k` : value}
             tickLine={false}
             axisLine={false}
             tickMargin={10}
           />
           <CartesianGrid strokeDasharray="3 3" vertical={false} />
-          <Tooltip content={<CustomTooltip />} />
+          <Tooltip content={<CustomTooltip type={type} />} />
           <Area
             type="monotone"
-            dataKey="volume"
+            dataKey="value"
             stroke={chartColor}
             fillOpacity={1}
             fill="url(#colorVolume)"

--- a/analytics/src/components/TransactionChart.tsx
+++ b/analytics/src/components/TransactionChart.tsx
@@ -20,7 +20,12 @@ interface TransactionChartProps {
   type: 'volume' | 'transactions'
 }
 
-const CustomTooltip = ({ active, payload, label, type }: TooltipProps<number, string> & { type: 'volume' | 'transactions' }) => {
+const CustomTooltip = ({
+  active,
+  payload,
+  label,
+  type,
+}: TooltipProps<number, string> & { type: 'volume' | 'transactions' }) => {
   if (!active || !payload || !payload.length) {
     return null
   }
@@ -55,7 +60,7 @@ export default function TransactionChart({ data, type }: TransactionChartProps) 
           </defs>
           <XAxis dataKey="date" tickLine={false} axisLine={false} tickMargin={10} />
           <YAxis
-            tickFormatter={value => type === 'volume' ? `$${(value / 1000).toFixed(0)}k` : value}
+            tickFormatter={value => (type === 'volume' ? `$${(value / 1000).toFixed(0)}k` : value)}
             tickLine={false}
             axisLine={false}
             tickMargin={10}

--- a/analytics/src/models/Transaction.ts
+++ b/analytics/src/models/Transaction.ts
@@ -140,7 +140,7 @@ transactionSchema.index({ destinationTokenId: 1 }) // For destination token filt
 
 // Compound indexes for analytics
 transactionSchema.index({ status: 1, txDate: -1 }) // For status and date queries
-transactionSchema.index({ status: 1, sourceTokenId: 1, sourceTokenAmountUsd: 1 }) // For token volume analytics (getTokensData)
+transactionSchema.index({ status: 1, sourceTokenId: 1, sourceTokenAmountUsd: 1 }) // For token volume analytics (getTokensData) and top tokens by count
 transactionSchema.index({ status: 1, txDate: -1, sourceTokenAmountUsd: 1 }) // For monthly volume calculations (getSummaryData)
 
 // Compound indexes for filtered queries

--- a/app/src/hooks/useParaspellApi.ts
+++ b/app/src/hooks/useParaspellApi.ts
@@ -171,7 +171,13 @@ const useParaspellApi = () => {
             })
           })
         } catch (error) {
-          handleSendError(params.sender, error, setStatus, event.txHash.toString(), params.environment)
+          handleSendError(
+            params.sender,
+            error,
+            setStatus,
+            event.txHash.toString(),
+            params.environment,
+          )
         }
       },
       error: callbackError => {
@@ -247,7 +253,13 @@ const useParaspellApi = () => {
             })
           })
         } catch (error) {
-          handleSendError(params.sender, error, setStatus, event.txHash.toString(), params.environment)
+          handleSendError(
+            params.sender,
+            error,
+            setStatus,
+            event.txHash.toString(),
+            params.environment,
+          )
         }
       },
       error: callbackError => {

--- a/app/src/hooks/useParaspellApi.ts
+++ b/app/src/hooks/useParaspellApi.ts
@@ -171,7 +171,7 @@ const useParaspellApi = () => {
             })
           })
         } catch (error) {
-          handleSendError(params.sender, error, setStatus, event.txHash.toString())
+          handleSendError(params.sender, error, setStatus, event.txHash.toString(), params.environment)
         }
       },
       error: callbackError => {
@@ -247,7 +247,7 @@ const useParaspellApi = () => {
             })
           })
         } catch (error) {
-          handleSendError(params.sender, error, setStatus, event.txHash.toString())
+          handleSendError(params.sender, error, setStatus, event.txHash.toString(), params.environment)
         }
       },
       error: callbackError => {
@@ -394,6 +394,7 @@ const useParaspellApi = () => {
     e: unknown,
     setStatus: (status: Status) => void,
     txId?: string,
+    environment?: string,
   ) => {
     setStatus('Idle')
     console.log('Transfer error:', e)
@@ -407,6 +408,14 @@ const useParaspellApi = () => {
       message,
       severity: NotificationSeverity.Error,
     })
+
+    if (txId && environment) {
+      updateTransferMetrics({
+        txHashId: txId,
+        status: TxStatus.Failed,
+        environment: environment,
+      })
+    }
   }
 
   return { transfer }


### PR DESCRIPTION
Currently, the dashboard home displays statistics based solely on volume. We want to enhance this by including the same graphs that represent transaction count as well. This PR introduces a toggle feature, allowing users to switch between viewing data by volume and by the number of transactions.

Also, include a scenario where we need to update the transaction status to fail if the tracking fails.