### PR TITLE
Chore: Update Phala RPC connection URL

### DIFF
--- a/packages/registry/src/mainnet/chains.ts
+++ b/packages/registry/src/mainnet/chains.ts
@@ -90,7 +90,7 @@ export const Phala: Chain = {
   network: "Polkadot",
   supportedAddressTypes: ["ss58"],
   walletType: "Substrate",
-  rpcConnection: `wss://api-phala.dwellir.com/${DWELLIR_KEY}`,
+  rpcConnection: `wss://api-phala.n.dwellir.com/${DWELLIR_KEY}`,
 };
 
 export const Moonbeam: Chain = {


### PR DESCRIPTION
We recieved another email asking to update the URL 

![Screenshot 2025-06-27 at 13 24 37](https://github.com/user-attachments/assets/b8febb0c-c17b-4216-a6eb-47db8e4d378a)
