### PR TITLE
Imp: Centralize router builder logic into dedicated singletons

### DIFF
--- a/app/src/hooks/useOutputAmount.tsx
+++ b/app/src/hooks/useOutputAmount.tsx
@@ -2,8 +2,9 @@ import { captureException } from '@sentry/nextjs'
 import { useQuery } from '@tanstack/react-query'
 import { Chain, Token, isSameToken } from '@velocitylabs-org/turtle-registry'
 import { useMemo } from 'react'
+import { TransferParams } from '@/hooks/useTransfer'
 import { AmountInfo } from '@/models/transfer'
-import { getExchangeOutputAmount } from '@/utils/paraspellSwap'
+import xcmRouterBuilderManager from '@/services/xcmRouterBuilder'
 
 interface UseOutputAmountParams {
   sourceChain?: Chain | null
@@ -47,12 +48,15 @@ export function useOutputAmount({
       try {
         if (!isSameToken(sourceToken, destinationToken)) {
           // Swap
-          const output = await getExchangeOutputAmount(
+          const params = {
             sourceChain,
             destinationChain,
             sourceToken,
             destinationToken,
-            amount,
+            sourceAmount: amount,
+          }
+          const output = await xcmRouterBuilderManager.getExchangeOutputAmount(
+            params as unknown as TransferParams,
           )
           return output
         }

--- a/app/src/hooks/useParaspellApi.ts
+++ b/app/src/hooks/useParaspellApi.ts
@@ -4,24 +4,21 @@ import { isSameToken } from '@velocitylabs-org/turtle-registry'
 import { switchChain } from '@wagmi/core'
 import { InvalidTxError, TxEvent } from 'polkadot-api'
 import { getPolkadotSignerFromPjs, SignPayload, SignRaw } from 'polkadot-api/pjs-signer'
+import { type Client } from 'viem'
 import { Config, useConnectorClient } from 'wagmi'
 import { moonbeam } from 'wagmi/chains'
 import { config } from '@/config'
 import { NotificationSeverity } from '@/models/notification'
 import { CompletedTransfer, OnChainBaseEvents, StoredTransfer, TxStatus } from '@/models/transfer'
 import { getCachedTokenPrice } from '@/services/balance'
+import evmTransferBuilderManager from '@/services/evmTransferBuilder'
+import xcmRouterBuilderManager from '@/services/xcmRouterBuilder'
+import xcmTransferBuilderManager from '@/services/xcmTransferBuilder'
 import { SubstrateAccount } from '@/store/substrateWalletStore'
 import { getSenderAddress } from '@/utils/address'
 import { trackTransferMetrics, updateTransferMetrics } from '@/utils/analytics'
 import { extractPapiEvent } from '@/utils/papi'
-import { createRouterPlan } from '@/utils/paraspellSwap'
-import {
-  createTransferTx,
-  dryRun,
-  DryRunResult,
-  isExistentialDepositMetAfterTransfer,
-  moonbeamTransfer,
-} from '@/utils/paraspellTransfer'
+import { DryRunResult } from '@/utils/paraspellTransfer'
 import {
   getExplorerLink,
   isSameChainSwap,
@@ -59,7 +56,8 @@ const useParaspellApi = () => {
     setStatus: (status: Status) => void,
   ) => {
     await switchChain(config, { chainId: moonbeam.id })
-    const hash = await moonbeamTransfer(params, viemClient)
+    const hash = await evmTransferBuilderManager.transferTx(params, viemClient as Client)
+    setStatus('Signing')
 
     const senderAddress = await getSenderAddress(params.sender)
     const sourceTokenUSDValue = (await getCachedTokenPrice(params.sourceToken))?.usd ?? 0
@@ -93,6 +91,7 @@ const useParaspellApi = () => {
         destinationTokenUSDValue,
         date,
       })
+      evmTransferBuilderManager.disconnect(params)
     })
 
     setStatus('Idle')
@@ -110,7 +109,7 @@ const useParaspellApi = () => {
     // Validate the transfer
     setStatus('Validating')
 
-    const validationResult = await validateTransfer(params)
+    const validationResult = await validatePolkadotTransfer(params)
 
     const dryRunCapturePayload = {
       extra: {
@@ -147,13 +146,14 @@ const useParaspellApi = () => {
       }
 
       if (validationResult.origin.success && validationResult.destination?.success) {
-        const isExistentialDepositMet = await isExistentialDepositMetAfterTransfer(params)
+        const isExistentialDepositMet =
+          await xcmTransferBuilderManager.isExistentialDepositMetAfterTransfer(params)
         if (!isExistentialDepositMet)
           throw new Error('Transfer failed: existential deposit will not be met.')
       }
     }
 
-    const tx = await createTransferTx(params, params.sourceChain.rpcConnection)
+    const tx = await xcmTransferBuilderManager.createTransferTx(params)
     setStatus('Signing')
 
     const polkadotSigner = getPolkadotSignerFromPjs(
@@ -197,9 +197,11 @@ const useParaspellApi = () => {
               destinationTokenUSDValue,
               date,
             })
+            xcmTransferBuilderManager.disconnect(params)
           })
         } catch (error) {
           handleSendError(params.sender, error, setStatus, event.txHash.toString())
+          xcmTransferBuilderManager.disconnect(params)
         }
       },
       error: callbackError => {
@@ -208,8 +210,12 @@ const useParaspellApi = () => {
           handleSendError(params.sender, callbackError, setStatus)
         }
         handleSendError(params.sender, callbackError, setStatus)
+        xcmTransferBuilderManager.disconnect(params)
       },
-      complete: () => console.log('The transaction is complete'),
+      complete: () => {
+        console.log('The transaction is complete')
+        xcmTransferBuilderManager.disconnect(params)
+      },
     })
 
     setStatus('Sending')
@@ -226,7 +232,7 @@ const useParaspellApi = () => {
     const destinationTokenUSDValue = (await getCachedTokenPrice(params.destinationToken))?.usd ?? 0
     const date = new Date()
 
-    const routerPlan = await createRouterPlan(params)
+    const routerPlan = await xcmRouterBuilderManager.createRouterPlan(params)
 
     const firstTransaction = routerPlan.at(0)
     if (!firstTransaction) throw new Error('No steps in router plan')
@@ -273,15 +279,21 @@ const useParaspellApi = () => {
               date,
               isSwap: true,
             })
+            xcmRouterBuilderManager.disconnect(params)
           })
         } catch (error) {
           handleSendError(params.sender, error, setStatus, event.txHash.toString())
+          await xcmRouterBuilderManager.disconnect(params)
         }
       },
-      error: callbackError => {
+      error: (callbackError: any) => {
         handleSendError(params.sender, callbackError, setStatus)
+        xcmRouterBuilderManager.disconnect(params)
       },
-      complete: () => console.log('The swap transaction is complete'),
+      complete: () => {
+        console.log('The swap transaction is complete')
+        xcmRouterBuilderManager.disconnect(params)
+      },
     })
 
     setStatus('Sending')
@@ -396,9 +408,9 @@ const useParaspellApi = () => {
     return defaultDryRunMessage
   }
 
-  const validateTransfer = async (params: TransferParams): Promise<DryRunResult> => {
+  const validatePolkadotTransfer = async (params: TransferParams): Promise<DryRunResult> => {
     try {
-      const result = await dryRun(params, params.sourceChain.rpcConnection)
+      const result = await xcmTransferBuilderManager.dryRun(params)
       if (
         !isDryRunApiSupported(result.origin) ||
         (result.destination && !isDryRunApiSupported(result.destination))

--- a/app/src/hooks/useTransferForm.ts
+++ b/app/src/hooks/useTransferForm.ts
@@ -14,12 +14,12 @@ import { mainnet } from 'viem/chains'
 import { config } from '@/config'
 import useBalance from '@/hooks/useBalance'
 import { useOutputAmount } from '@/hooks/useOutputAmount'
-import useTransfer from '@/hooks/useTransfer'
+import useTransfer, { TransferParams } from '@/hooks/useTransfer'
 import useWallet from '@/hooks/useWallet'
 import { NotificationSeverity } from '@/models/notification'
 import { schema } from '@/models/schemas'
+import xcmTransferBuilderManager from '@/services/xcmTransferBuilder'
 import { getRecipientAddress, isValidAddressType } from '@/utils/address'
-import { getTransferableAmount } from '@/utils/paraspellTransfer'
 import { isRouteAllowed, isTokenAvailableForSourceChain } from '@/utils/routes'
 import { formatAmount, safeConvertAmount, toHuman } from '@/utils/transfer'
 import useFees from './useFees'
@@ -245,13 +245,16 @@ const useTransferForm = () => {
       const recipient =
         getRecipientAddress(manualRecipient, destinationWallet) ?? destinationWallet.sender.address
 
-      const transferableAmount = await getTransferableAmount(
+      const params = {
         sourceChain,
         destinationChain,
-        sourceTokenAmount.token,
+        sourceToken: sourceTokenAmount.token,
         recipient,
-        sourceWallet.sender.address,
-        balanceData.value,
+        sender: sourceWallet.sender,
+        sourceAmount: balanceData.value,
+      }
+      const transferableAmount = await xcmTransferBuilderManager.getTransferableAmount(
+        params as unknown as TransferParams,
       )
 
       setValue(

--- a/app/src/services/evmTransferBuilder.ts
+++ b/app/src/services/evmTransferBuilder.ts
@@ -1,0 +1,91 @@
+import { EvmBuilder } from '@paraspell/sdk'
+import { type Client } from 'viem'
+import { TransferParams } from '@/hooks/useTransfer'
+import { getParaSpellNode, getParaspellToken } from '@/utils/paraspellTransfer'
+
+type TxBuilder = ReturnType<typeof EvmBuilder>
+
+class EvmTransferBuilderManager {
+  private static instance: EvmTransferBuilderManager
+  private builders: Map<string, TxBuilder>
+
+  private constructor() {
+    this.builders = new Map()
+  }
+
+  static getInstance(): EvmTransferBuilderManager {
+    if (!EvmTransferBuilderManager.instance) {
+      EvmTransferBuilderManager.instance = new EvmTransferBuilderManager()
+    }
+    return EvmTransferBuilderManager.instance
+  }
+
+  createBuilder(params: TransferParams): TxBuilder {
+    const { sourceChain, destinationChain, sourceToken, sourceAmount, recipient } = params
+    const sourceChainNode = getParaSpellNode(sourceChain)
+    const destinationChainNode = getParaSpellNode(destinationChain)
+
+    if (!sourceChainNode || !destinationChainNode) {
+      throw new Error('Failed to create builder: chain id not found.')
+    }
+
+    const currencyId = getParaspellToken(sourceToken, sourceChainNode)
+    const key = txKey(params)
+
+    if (this.builders.has(key)) return this.builders.get(key)!
+
+    let builder: TxBuilder
+    try {
+      builder = EvmBuilder()
+        .from(sourceChainNode)
+        .to(destinationChainNode)
+        .currency({ ...currencyId, amount: sourceAmount })
+        .address(recipient)
+
+      this.builders.set(key, builder)
+    } catch (error) {
+      console.error('Failed to create builder: ', error)
+      throw error
+    }
+
+    return builder
+  }
+
+  getBuilder(params: TransferParams) {
+    const key = txKey(params)
+    const existing = this.builders.get(key)
+    return existing ?? this.createBuilder(params)
+  }
+
+  async transferTx(params: TransferParams, viemClient: Client) {
+    try {
+      const builder = this.getBuilder(params) as any
+      return await builder.signer(viemClient).build()
+    } catch (error) {
+      console.error('Failed to create transfer tx: ', error)
+      throw error
+    }
+  }
+
+  async disconnect(params: TransferParams) {
+    this.removeBuilder(params)
+    return true
+  }
+
+  removeBuilder(params: TransferParams) {
+    const key = txKey(params)
+    this.builders.delete(key)
+  }
+
+  builderList() {
+    return this.builders
+  }
+}
+
+function txKey(params: TransferParams): string {
+  const { sourceChain, destinationChain, sourceToken, sourceAmount, recipient } = params
+  return [sourceChain.uid, destinationChain.uid, sourceToken.id, sourceAmount, recipient].join('|')
+}
+
+const evmTransferBuilderManager = EvmTransferBuilderManager.getInstance()
+export default evmTransferBuilderManager

--- a/app/src/services/xcmRouterBuilder.ts
+++ b/app/src/services/xcmRouterBuilder.ts
@@ -1,0 +1,127 @@
+import { RouterBuilder } from '@paraspell/xcm-router'
+import { TransferParams } from '@/hooks/useTransfer'
+import { SubstrateAccount } from '@/store/substrateWalletStore'
+import { getSenderAddress } from '@/utils/address'
+import { type Dex } from '@/utils/paraspellSwap'
+import { getParaSpellNode, getParaspellToken } from '@/utils/paraspellTransfer'
+
+type TxBuilder = ReturnType<typeof RouterBuilder>
+
+class XcmRouterBuilderManager {
+  private static instance: XcmRouterBuilderManager
+  private builders: Map<string, TxBuilder>
+
+  private constructor() {
+    this.builders = new Map()
+  }
+
+  static getInstance(): XcmRouterBuilderManager {
+    if (!XcmRouterBuilderManager.instance) {
+      XcmRouterBuilderManager.instance = new XcmRouterBuilderManager()
+    }
+    return XcmRouterBuilderManager.instance
+  }
+
+  createBuilder(params: TransferParams, exchange: Dex = 'HydrationDex'): TxBuilder {
+    const { sourceChain, destinationChain, sourceToken, destinationToken, sourceAmount } = params
+    const sourceChainFromId = getParaSpellNode(sourceChain)
+    const destinationChainFromId = getParaSpellNode(destinationChain)
+
+    if (!sourceChainFromId || !destinationChainFromId)
+      throw new Error('Transfer failed: chain id not found.')
+    if (sourceChainFromId === 'Ethereum' || destinationChainFromId === 'Ethereum')
+      throw new Error('Transfer failed: Ethereum is not supported.')
+
+    const currencyIdFrom = getParaspellToken(sourceToken, sourceChainFromId)
+    const currencyTo = getParaspellToken(destinationToken, destinationChainFromId)
+    const key = txKey(params, exchange)
+
+    if (this.builders.has(key)) return this.builders.get(key)!
+
+    let builder: TxBuilder
+    try {
+      builder = RouterBuilder()
+        .from(sourceChainFromId)
+        .to(destinationChainFromId)
+        .exchange(exchange as any)
+        .currencyFrom(currencyIdFrom)
+        .currencyTo(currencyTo)
+        .amount(sourceAmount)
+
+      this.builders.set(key, builder)
+    } catch (error) {
+      console.error('Failed to create builder: ', error)
+      throw error
+    }
+
+    return builder
+  }
+
+  getBuilder(params: TransferParams, exchange: Dex) {
+    const key = txKey(params, exchange)
+    const existing = this.builders.get(key)
+    return existing ?? this.createBuilder(params, exchange)
+  }
+
+  async createRouterPlan(
+    params: TransferParams,
+    exchange: Dex = 'HydrationDex',
+    slippagePct: string = '1',
+  ) {
+    try {
+      const account = params.sender as SubstrateAccount
+      const senderAddress = await getSenderAddress(params.sender)
+      const recipientAddress = params.recipient
+      const builder = this.getBuilder(params, exchange) as any
+      return await builder
+        .slippagePct(slippagePct)
+        .senderAddress(senderAddress)
+        .recipientAddress(recipientAddress)
+        .signer(account.pjsSigner as any)
+        .buildTransactions()
+    } catch (error) {
+      console.error('Failed to create transfer tx: ', error)
+      throw error
+    }
+  }
+
+  async getExchangeOutputAmount(params: TransferParams, exchange: Dex = 'HydrationDex') {
+    try {
+      const builder = this.getBuilder(params, exchange)
+      const amountOut = await (builder as any).getBestAmountOut()
+      return amountOut.amountOut
+    } catch (error) {
+      console.error('Failed to get best Amount Out: ', error)
+      throw error
+    }
+  }
+
+  disconnect(params: TransferParams) {
+    this.removeBuilder(params)
+    return true
+  }
+
+  removeBuilder(params: TransferParams, exchange: Dex = 'HydrationDex') {
+    const key = txKey(params, exchange)
+    this.builders.delete(key)
+  }
+
+  builderList() {
+    return this.builders
+  }
+}
+
+function txKey(params: TransferParams, exchange: Dex): string {
+  const { sourceChain, destinationChain, sourceToken, destinationToken, sourceAmount } = params
+  return [
+    sourceChain.uid,
+    destinationChain.uid,
+    sourceToken.id,
+    destinationToken.id,
+    sourceAmount,
+    exchange,
+  ].join('|')
+}
+
+const xcmRouterBuilderManager = XcmRouterBuilderManager.getInstance()
+export default xcmRouterBuilderManager

--- a/app/src/services/xcmTransferBuilder.ts
+++ b/app/src/services/xcmTransferBuilder.ts
@@ -1,0 +1,144 @@
+import {
+  Builder,
+  GeneralBuilder,
+  TNodeDotKsmWithRelayChains,
+  TSendBaseOptionsWithSenderAddress,
+} from '@paraspell/sdk'
+import { TransferParams } from '@/hooks/useTransfer'
+import { getParaSpellNode, getParaspellToken } from '@/utils/paraspellTransfer'
+
+type TxBuilder = ReturnType<typeof Builder>
+
+class XcmTransferBuilderManager {
+  private static instance: XcmTransferBuilderManager
+  private builders: Map<string, TxBuilder>
+
+  private constructor() {
+    this.builders = new Map()
+  }
+
+  static getInstance(): XcmTransferBuilderManager {
+    if (!XcmTransferBuilderManager.instance) {
+      XcmTransferBuilderManager.instance = new XcmTransferBuilderManager()
+    }
+    return XcmTransferBuilderManager.instance
+  }
+
+  createBuilder(params: TransferParams): TxBuilder {
+    const { sourceChain, destinationChain, sourceToken, sourceAmount, recipient, sender } = params
+    const wssEndpoint = sourceChain.rpcConnection
+    const sourceChainNode = getParaSpellNode(sourceChain)
+    const destinationChainNode = getParaSpellNode(destinationChain)
+
+    if (!sourceChainNode || !destinationChainNode) {
+      throw new Error('Failed to create builder: chain id not found.')
+    }
+
+    const currencyId = getParaspellToken(sourceToken, sourceChainNode)
+    const key = txKey(params)
+
+    if (this.builders.has(key)) return this.builders.get(key)!
+
+    let builder: TxBuilder
+    try {
+      builder = Builder(wssEndpoint)
+        .from(sourceChainNode as TNodeDotKsmWithRelayChains)
+        .to(destinationChainNode as TNodeDotKsmWithRelayChains)
+        .currency({ ...currencyId, amount: sourceAmount })
+        .address(recipient)
+        .senderAddress(sender.address)
+
+      this.builders.set(key, builder)
+    } catch (error) {
+      console.error('Failed to create builder: ', error)
+      throw error
+    }
+
+    return builder
+  }
+
+  getBuilder(params: TransferParams) {
+    const key = txKey(params)
+    const existing = this.builders.get(key)
+    return existing ?? this.createBuilder(params)
+  }
+
+  async isExistentialDepositMetAfterTransfer(params: TransferParams) {
+    try {
+      const builder = this.getBuilder(params)
+      return await (
+        builder as GeneralBuilder<TSendBaseOptionsWithSenderAddress>
+      ).verifyEdOnDestination()
+    } catch (error) {
+      console.error('Failed to verify existential deposit: ', error)
+      return false
+    }
+  }
+
+  async dryRun(params: TransferParams) {
+    try {
+      const builder = this.getBuilder(params)
+      return await (builder as GeneralBuilder<TSendBaseOptionsWithSenderAddress>).dryRun()
+    } catch (error) {
+      console.error('Failed to dry run: ', error)
+      throw error
+    }
+  }
+
+  async getTransferableAmount(params: TransferParams) {
+    const builder = this.getBuilder(params)
+    return await (
+      builder as GeneralBuilder<TSendBaseOptionsWithSenderAddress>
+    ).getTransferableAmount()
+  }
+
+  async createTransferTx(params: TransferParams) {
+    try {
+      const builder = this.getBuilder(params)
+      return await (builder as GeneralBuilder<TSendBaseOptionsWithSenderAddress>)
+        .senderAddress(params.sender.address)
+        .build()
+    } catch (error) {
+      console.error('Failed to create transfer tx: ', error)
+      throw error
+    }
+  }
+
+  async disconnect(params: TransferParams) {
+    try {
+      const builder = this.getBuilder(params)
+      await (builder as GeneralBuilder<TSendBaseOptionsWithSenderAddress>).disconnect()
+      this.removeBuilder(params)
+      return true
+    } catch (error) {
+      console.error('Failed to disconnect: ', error)
+      return false
+    }
+  }
+
+  removeBuilder(params: TransferParams) {
+    const key = txKey(params)
+    this.builders.delete(key)
+  }
+
+  builderList() {
+    return this.builders
+  }
+}
+
+function txKey(params: TransferParams): string {
+  const { sourceChain, destinationChain, sourceToken, sourceAmount, recipient, sender } = params
+  const wssEndpoint = sourceChain.rpcConnection
+  return [
+    ...(wssEndpoint ? [wssEndpoint] : []),
+    sourceChain.uid,
+    destinationChain.uid,
+    sourceToken.id,
+    sourceAmount,
+    recipient,
+    sender.address,
+  ].join('|')
+}
+
+const xcmTransferBuilderManager = XcmTransferBuilderManager.getInstance()
+export default xcmTransferBuilderManager

--- a/app/src/utils/paraspellSwap.ts
+++ b/app/src/utils/paraspellSwap.ts
@@ -1,4 +1,4 @@
-import { getExchangePairs, RouterBuilder } from '@paraspell/xcm-router'
+import { getExchangePairs } from '@paraspell/xcm-router'
 import {
   Chain,
   Token,
@@ -7,11 +7,7 @@ import {
   getTokenByMultilocation,
   isSameToken,
 } from '@velocitylabs-org/turtle-registry'
-import { TransferParams } from '@/hooks/useTransfer'
-import { SubstrateAccount } from '@/store/substrateWalletStore'
 import { deduplicate, isSameChain } from '@/utils/routes'
-import { getSenderAddress } from './address'
-import { getParaSpellNode, getParaspellToken } from './paraspellTransfer'
 
 // We only support Hydration for now.
 /** contains all supported paraspell dexes mapped to the chain they run on */
@@ -20,77 +16,6 @@ export const DEX_TO_CHAIN_MAP = {
 } as const
 
 export type Dex = keyof typeof DEX_TO_CHAIN_MAP
-
-export const createRouterPlan = async (params: TransferParams, slippagePct: string = '1') => {
-  const {
-    sourceChain,
-    destinationChain,
-    sourceToken,
-    destinationToken,
-    sourceAmount,
-    recipient,
-    sender,
-  } = params
-
-  const senderAddress = await getSenderAddress(sender)
-  const account = params.sender as SubstrateAccount
-  const sourceChainFromId = getParaSpellNode(sourceChain)
-  const destinationChainFromId = getParaSpellNode(destinationChain)
-
-  if (!sourceChainFromId || !destinationChainFromId)
-    throw new Error('Transfer failed: chain id not found.')
-  if (sourceChainFromId === 'Ethereum' || destinationChainFromId === 'Ethereum')
-    throw new Error('Transfer failed: Ethereum is not supported.')
-
-  const currencyIdFrom = getParaspellToken(sourceToken, sourceChainFromId)
-  const currencyTo = getParaspellToken(destinationToken, destinationChainFromId)
-
-  const routerPlan = await RouterBuilder()
-    .from(sourceChainFromId)
-    .to(destinationChainFromId)
-    .exchange('HydrationDex')
-    .currencyFrom(currencyIdFrom)
-    .currencyTo(currencyTo)
-    .amount(sourceAmount)
-    .slippagePct(slippagePct)
-    .senderAddress(senderAddress)
-    .recipientAddress(recipient)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .signer(account.pjsSigner as any)
-    .buildTransactions()
-
-  return routerPlan
-}
-
-export const getExchangeOutputAmount = async (
-  sourceChain: Chain,
-  destinationChain: Chain,
-  sourceToken: Token,
-  destinationToken: Token,
-  /** Amount in the source token's decimal base */
-  amount: string,
-): Promise<bigint> => {
-  const sourceChainFromId = getParaSpellNode(sourceChain)
-  const destinationChainFromId = getParaSpellNode(destinationChain)
-  if (!sourceChainFromId || !destinationChainFromId)
-    throw new Error('Transfer failed: chain id not found.')
-  if (sourceChainFromId === 'Ethereum' || destinationChainFromId === 'Ethereum')
-    throw new Error('Transfer failed: Ethereum is not supported.')
-
-  const currencyIdFrom = getParaspellToken(sourceToken, sourceChainFromId)
-  const currencyTo = getParaspellToken(destinationToken, destinationChainFromId)
-
-  const amountOut = await RouterBuilder()
-    .from(sourceChainFromId)
-    .to(destinationChainFromId)
-    .exchange('HydrationDex')
-    .currencyFrom(currencyIdFrom)
-    .currencyTo(currencyTo)
-    .amount(amount)
-    .getBestAmountOut()
-
-  return amountOut.amountOut
-}
 
 /** returns all supported dex paraspell nodes */
 export const getSupportedDexNodes = () => Object.keys(DEX_TO_CHAIN_MAP)

--- a/app/src/utils/paraspellTransfer.ts
+++ b/app/src/utils/paraspellTransfer.ts
@@ -1,6 +1,4 @@
 import {
-  Builder,
-  EvmBuilder,
   findAsset,
   getAllAssetsSymbols,
   getNativeAssetSymbol,
@@ -8,150 +6,12 @@ import {
   TCurrencyCore,
   TDryRunResult,
   TEcosystemType,
-  TNodeDotKsmWithRelayChains,
   TNodeWithRelayChains,
-  type TPapiTransaction,
 } from '@paraspell/sdk'
 import { captureException } from '@sentry/nextjs'
 import { Chain, Token, EthereumTokens, REGISTRY, Network } from '@velocitylabs-org/turtle-registry'
-import { TransferParams } from '@/hooks/useTransfer'
 
 export type DryRunResult = { type: 'Supported' | 'Unsupported' } & TDryRunResult
-
-/**
- * Creates a submittable PAPI transaction using Paraspell Builder.
- *
- * @param params - The transfer parameters
- * @param wssEndpoint - An optional wss chain endpoint to connect to a specific blockchain.
- * @returns - A Promise that resolves a submittable extrinsic transaction.
- */
-export const createTransferTx = async (
-  params: TransferParams,
-  wssEndpoint?: string,
-): Promise<TPapiTransaction> => {
-  const { sourceChain, destinationChain, sourceToken, sourceAmount, recipient, sender } = params
-
-  const sourceChainNode = getParaSpellNode(sourceChain)
-  const destinationChainNode = getParaSpellNode(destinationChain)
-
-  if (!sourceChainNode || !destinationChainNode)
-    throw new Error('Transfer failed: chain id not found.')
-
-  const currencyId = getParaspellToken(sourceToken, sourceChainNode)
-
-  return await Builder(wssEndpoint)
-    .from(sourceChainNode as TNodeDotKsmWithRelayChains)
-    .to(destinationChainNode)
-    .currency({ ...currencyId, amount: sourceAmount })
-    .address(recipient)
-    .senderAddress(sender.address)
-    .build()
-}
-
-/**
- * Submits a moonbeam xcm transaction using Paraspell EvmBuilder.
- *
- * @param params - The transfer parameters
- * @returns - A Promise that resolves to the tx hash.
- */
-export const moonbeamTransfer = async (
-  params: TransferParams,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  viemClient: any,
-): Promise<string> => {
-  const { sourceChain, destinationChain, sourceToken, sourceAmount, recipient } = params
-
-  const sourceChainFromId = getParaSpellNode(sourceChain)
-  const destinationChainFromId = getParaSpellNode(destinationChain)
-  if (!sourceChainFromId || !destinationChainFromId)
-    throw new Error('Transfer failed: chain id not found.')
-
-  const currencyId = getParaspellToken(sourceToken, sourceChainFromId)
-
-  return EvmBuilder()
-    .from('Moonbeam')
-    .to(destinationChainFromId)
-    .currency({ ...currencyId, amount: sourceAmount })
-    .address(recipient)
-    .signer(viemClient)
-    .build()
-}
-
-/**
- * Dry run a transfer using Paraspell.
- *
- * @param params - The transfer parameters
- * @param wssEndpoint - An optional wss chain endpoint to connect to a specific blockchain.
- * @returns - A Promise that resolves a dry run result.
- * @throws - An error if the dry run api is not available.
- */
-export const dryRun = async (
-  params: TransferParams,
-  wssEndpoint?: string,
-): Promise<TDryRunResult> => {
-  const { sourceChain, destinationChain, sourceToken, sourceAmount, recipient, sender } = params
-  const sourceChainNode = getParaSpellNode(sourceChain)
-  const destinationChainNode = getParaSpellNode(destinationChain)
-  if (!sourceChainNode || !destinationChainNode)
-    throw new Error('Dry Run failed: chain id not found.')
-
-  const currencyId = getParaspellToken(sourceToken, sourceChainNode)
-
-  return await Builder(wssEndpoint)
-    .from(sourceChainNode as TNodeDotKsmWithRelayChains)
-    .to(destinationChainNode)
-    .currency({ ...currencyId, amount: sourceAmount })
-    .address(recipient)
-    .senderAddress(sender.address)
-    .dryRun()
-}
-
-export const isExistentialDepositMetAfterTransfer = async (
-  params: TransferParams,
-  wssEndpoint?: string,
-): Promise<boolean> => {
-  const { sourceChain, destinationChain, sourceToken, sourceAmount, recipient, sender } = params
-  const sourceChainNode = getParaSpellNode(sourceChain)
-  const destinationChainNode = getParaSpellNode(destinationChain)
-  if (!sourceChainNode || !destinationChainNode)
-    throw new Error('Dry Run failed: chain id not found.')
-
-  const currencyId = getParaspellToken(sourceToken, sourceChainNode)
-
-  return await Builder(wssEndpoint)
-    .from(sourceChainNode as TNodeDotKsmWithRelayChains)
-    .to(destinationChainNode)
-    .currency({ ...currencyId, amount: sourceAmount })
-    .address(recipient)
-    .senderAddress(sender.address)
-    .verifyEdOnDestination()
-}
-
-export const getTransferableAmount = async (
-  sourceChain: Chain,
-  destinationChain: Chain,
-  sourceToken: Token,
-  recipient: string,
-  sender: string,
-  userBalance: bigint,
-  wssEndpoint?: string,
-): Promise<bigint> => {
-  const sourceChainNode = getParaSpellNode(sourceChain)
-  const destinationChainNode = getParaSpellNode(destinationChain)
-  if (!sourceChainNode || !destinationChainNode)
-    throw new Error('Failed to get transferable amount: chain id not found.')
-
-  const currencyId = getParaspellToken(sourceToken, sourceChainNode)
-
-  return await Builder(wssEndpoint)
-    .from(sourceChainNode as TNodeDotKsmWithRelayChains)
-    .to(destinationChainNode)
-    // Pass a dummy amount
-    .currency({ ...currencyId, amount: userBalance })
-    .address(recipient)
-    .senderAddress(sender)
-    .getTransferableAmount()
-}
 
 export const getTokenSymbol = (sourceChain: TNodeWithRelayChains, token: Token) => {
   const supportedAssets = getAllAssetsSymbols(sourceChain)


### PR DESCRIPTION
This PR moves the paraspell builder logic into services, where we now store the builder as a singleton for caching purposes. This will allow us to use it later in methods that currently depend on the builder and cannot be exported directly from the SDK. I created one service for each type of transfer (EVM, SDK, and Router), and all three follow a similar logic. The next step is to create a Turtle core package and reuse this for the widget as well.