### PR TITLE
Fix: Add Solana support in Analytics

### DIFF
--- a/analytics/src/constants/index.tsx
+++ b/analytics/src/constants/index.tsx
@@ -1,4 +1,4 @@
-import { Ethereum, Polkadot, REGISTRY } from '@velocitylabs-org/turtle-registry'
+import { Ethereum, Moonbeam, Polkadot, REGISTRY } from '@velocitylabs-org/turtle-registry'
 
 export const primaryColor = '#00FF29'
 
@@ -14,6 +14,7 @@ export const transactionsPerPage = 10
 export const chains = REGISTRY.chains
 export const ethereumChain = Ethereum
 export const relayChain = Polkadot
+export const moonbeamChain = Moonbeam
 
 // Tokens
 export const tokens = REGISTRY.tokens

--- a/analytics/src/utils/get-type-badge.ts
+++ b/analytics/src/utils/get-type-badge.ts
@@ -1,11 +1,24 @@
-import { tokensById } from '@velocitylabs-org/turtle-registry'
-import { ethereumChain, relayChain } from '@/constants'
+import { type Chain, tokensById } from '@velocitylabs-org/turtle-registry'
+import { ethereumChain, moonbeamChain, relayChain } from '@/constants'
 import { getSrcFromLogo } from './get-src-from-logo'
 
-// This helper function returns the type badge for a given token (e.g., Ethereum or Polkadot)
+// This helper function returns the type badge for a given token (e.g., Ethereum, Polkadot or Solana)
 export default function getTypeBadge(tokenId: string) {
   const token = tokensById[tokenId]
-  const type = token.origin.type === 'Ethereum' ? ethereumChain : relayChain
+
+  let type: Chain
+  switch (token.origin.type) {
+    case 'Ethereum':
+      type = ethereumChain
+      break
+    case 'Solana':
+      type = moonbeamChain
+      break
+    case 'Polkadot':
+    default:
+      type = relayChain
+      break
+  }
 
   return {
     logoURI: getSrcFromLogo(token),


### PR DESCRIPTION
This PR adds support for origin type `Solana` in anlytics