### PR TITLE
Fix: Use soft hyphen for responsive word breaking in feature title

### DIFF
--- a/site/src/components/features.tsx
+++ b/site/src/components/features.tsx
@@ -13,7 +13,7 @@ export default function Features() {
       icon: turtle,
     },
     {
-      title: 'Trans&shy;parency all the way',
+      title: 'Trans\u00ADparency all the way', // u00AD is a soft hyphen for responsive word breaking
       description: `Keep an eye on your assets at every step of the way. The days of anxiously waiting for our funds to arrive are finally behind us!`,
       icon: chart,
     },


### PR DESCRIPTION
This PR addresses the issue related to word breaking. For more context, please refer to the following link: https://github.com/velocitylabs-org/turtle/pull/135/files.

<img width="450" height="300" alt="image" src="https://github.com/user-attachments/assets/543921ca-58c8-4a0d-80b9-fdf6c4821724" />
