### PR TITLE
Fix: Handle Moonbeam ERC-20 prefixes in token symbol resolution

### DIFF
--- a/app/src/hooks/useFees.ts
+++ b/app/src/hooks/useFees.ts
@@ -8,7 +8,11 @@ import type { FeeDetails } from '@/models/transfer'
 import { getCachedTokenPrice } from '@/services/balance'
 import xcmTransferBuilderManager from '@/services/paraspell/xcmTransferBuilder'
 import { Direction } from '@/services/transfer'
-import { getParaSpellNode, mapParaspellChainToTurtleRegistry } from '@/utils/paraspellTransfer'
+import {
+  getParaSpellNode,
+  mapParaspellChainToTurtleRegistry,
+  moonbeamSymbolToRegistry,
+} from '@/utils/paraspellTransfer'
 import { resolveSdk } from '@/utils/routes'
 import { getFeeEstimate } from '@/utils/snowbridge'
 import { isSwap, safeConvertAmount, toHuman } from '@/utils/transfer'
@@ -387,7 +391,10 @@ async function getTokenAmountInDollars(token: Token, amount: bigint): Promise<nu
   }
 }
 
-function getTokenFromSymbol(symbol: string): Token {
+function getTokenFromSymbol(symbolParam: string): Token {
+  // Moonbeam uses ERC-20 wrapped tokens with 'xc' prefix (e.g., xcDOT for wrapped DOT)
+  // Strip the 'xc' prefix to map to the base token in our registry
+  const symbol = moonbeamSymbolToRegistry(symbolParam)
   const symbolUpper = symbol.toUpperCase()
   const tokensBySymbol = { ...EthereumTokens, ...PolkadotTokens }
   const token = tokensBySymbol[symbolUpper as keyof typeof tokensBySymbol]

--- a/app/src/utils/paraspellTransfer.ts
+++ b/app/src/utils/paraspellTransfer.ts
@@ -114,3 +114,11 @@ export function mapParaspellChainToTurtleRegistry(chainName: string): Chain {
   }
   return chain
 }
+
+export function moonbeamSymbolToRegistry(tokenSymbol: string): string {
+  const moonbeamErc20Prefix = 'xc'
+  if (tokenSymbol.startsWith(moonbeamErc20Prefix)) {
+    return tokenSymbol.slice(moonbeamErc20Prefix.length)
+  }
+  return tokenSymbol
+}


### PR DESCRIPTION
This PR strip the `xc` prefix and map to the corresponding base token (e.g., xcDOT → DOT).

### Related Issue
Close [VEL-495](https://linear.app/velocitylabs/issue/VEL-495/map-xcdot-fees-to-dot-when-transferring-hydration-%E2%86%92-moonbeam)