### PR TITLE
Feat: chainflip/tracks swap, gets explorer, adds to metrics, & updates progress bar

### DIFF
--- a/app/src/components/TransferEstimate.tsx
+++ b/app/src/components/TransferEstimate.tsx
@@ -12,5 +12,5 @@ interface TransferEstimateProps {
 export default function TransferEstimate({ transfer, direction, outlinedProgressBar }: TransferEstimateProps) {
   const progress = useTransferProgress(transfer, direction)
 
-  return <ProgressBar progress={progress} outlinedProgressBar={outlinedProgressBar} />
+  return <ProgressBar progress={transfer.progress ?? progress} outlinedProgressBar={outlinedProgressBar} />
 }

--- a/app/src/components/ongoing/OngoingTransfers.tsx
+++ b/app/src/components/ongoing/OngoingTransfers.tsx
@@ -2,6 +2,7 @@
 import { type Chain, chainsByUid, type Token, tokensById } from '@velocitylabs-org/turtle-registry'
 import { colors } from '@velocitylabs-org/turtle-tailwind-config'
 import type { Dispatch, SetStateAction } from 'react'
+import { useChainflipTracker } from '@/hooks/useChainflipTracker'
 import useOcelloidsSubscribe from '@/hooks/useOcelloidsSubscribe'
 import useOngoingTransfersCleaner from '@/hooks/useOngoingTransferCleaner'
 import useOngoingTransfersTracker from '@/hooks/useOngoingTransfersTracker'
@@ -28,6 +29,7 @@ export default function OngoingTransfers({
 
   useOngoingTransfersCleaner(ongoingTransfers)
   useOcelloidsSubscribe(ongoingTransfers)
+  useChainflipTracker(ongoingTransfers)
 
   return (
     <div id="ongoing-txs">

--- a/app/src/hooks/useChainflipApi.ts
+++ b/app/src/hooks/useChainflipApi.ts
@@ -385,7 +385,6 @@ const handlePolkadotTxEvents = async (
   addOrUpdate({
     ...transferToStore,
     id: event.txHash.toString(),
-    status: `Arriving at ${transferToStore.destChain.name}`,
     finalizedAt: new Date(),
   })
   resolve()

--- a/app/src/hooks/useChainflipTracker.ts
+++ b/app/src/hooks/useChainflipTracker.ts
@@ -1,0 +1,150 @@
+import { captureException } from '@sentry/nextjs'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { type Notification, NotificationSeverity } from '@/models/notification'
+import { type CompletedTransfer, type StoredTransfer, TxStatus } from '@/models/transfer'
+import { truncateAddress } from '@/utils/address'
+import { updateTransferMetrics } from '@/utils/analytics'
+import { getChainflipOngoingSwaps, getSwapStatus } from '@/utils/chainflip'
+import { getChainflipExplorerLink } from '@/utils/transfer'
+import useCompletedTransfers from './useCompletedTransfers'
+import useNotification from './useNotification'
+import useOngoingTransfers from './useOngoingTransfers'
+
+const handleOngoingSwap = async (
+  swap: StoredTransfer,
+  updateStatus: (id: string, newStatus?: string) => void,
+  addCompletedSwap: (completedTransfer: CompletedTransfer) => void,
+  removeOngoingSwap: (id: string) => void,
+  addNotification: (notification: Omit<Notification, 'id'>) => void,
+): Promise<void> => {
+  const { sourceToken, sourceChain, destChain, destinationToken, id, uniqueTrackingId, recipient } = swap
+  if (!uniqueTrackingId) throw new Error(`Chainflip swap ${id} does not have a unique tracking id`)
+  const status = await getSwapStatus(uniqueTrackingId)
+  console.log('status', status)
+  const { state } = status
+  const formattedRecipient = truncateAddress(recipient)
+  switch (state) {
+    case 'RECEIVING': {
+      const newStatus = `${sourceToken.symbol} funds deposited`
+      updateStatus(id, newStatus)
+      break
+    }
+    case 'SWAPPING': {
+      const newStatus = `Swapping ${sourceToken.symbol} for ${destinationToken?.symbol}`
+      updateStatus(id, newStatus)
+      break
+    }
+    case 'SENDING': {
+      const newStatus = `Sending ${destinationToken?.symbol} to ${formattedRecipient}`
+      updateStatus(id, newStatus)
+      break
+    }
+    case 'SENT': {
+      const newStatus = `Finalizing swap on ${destChain.name} `
+      updateStatus(id, newStatus)
+      break
+    }
+    case 'COMPLETED':
+    case 'FAILED': {
+      const success = state === 'COMPLETED'
+      const swapStatus = success ? TxStatus.Succeeded : TxStatus.Failed
+      const newStatus = success ? 'Transfer completed!' : 'Transfer failed!'
+      updateStatus(id, newStatus)
+
+      addNotification({
+        message: newStatus,
+        severity: success ? NotificationSeverity.Success : NotificationSeverity.Error,
+        dismissible: true,
+      })
+
+      const explorerLink = getChainflipExplorerLink(swap, status.swapId)
+      addCompletedSwap({
+        id: id,
+        result: swapStatus,
+        sourceToken,
+        destinationToken,
+        sourceChain,
+        destChain,
+        sourceAmount: swap.sourceAmount,
+        destinationAmount: swap.destinationAmount,
+        sourceTokenUSDValue: swap.sourceTokenUSDValue ?? 0,
+        destinationTokenUSDValue: swap.destinationTokenUSDValue,
+        fees: swap.fees,
+        sender: swap.sender,
+        recipient,
+        date: swap.date,
+        ...(explorerLink && { explorerLink }),
+      } satisfies CompletedTransfer)
+
+      removeOngoingSwap(id)
+
+      updateTransferMetrics({
+        txHashId: swap.id,
+        status: swapStatus,
+      })
+
+      if (!success) {
+        captureException(new Error(`Chainflip swap ${id} failed - ${uniqueTrackingId}`), {
+          tags: { source: 'useChainflipTracker' },
+          extra: { swap, swapData: status },
+        })
+      }
+      break
+    }
+
+    default:
+      break
+  }
+}
+
+export const useChainflipTracker = (ongoingTransfers: StoredTransfer[]): void => {
+  // Ref to prevent polling overlap
+  const isPollingRef = useRef(false)
+  const { remove, updateStatus } = useOngoingTransfers()
+  const { addCompletedTransfer } = useCompletedTransfers()
+  const { addNotification } = useNotification()
+  const chainflipSwaps = useMemo(() => getChainflipOngoingSwaps(ongoingTransfers), [ongoingTransfers])
+
+  const pollStatuses = useCallback(
+    async (swaps: StoredTransfer[]) => {
+      if (swaps.length === 0 || isPollingRef.current) return
+      isPollingRef.current = true
+      try {
+        const results = await Promise.allSettled(
+          swaps.map(s => handleOngoingSwap(s, updateStatus, addCompletedTransfer, remove, addNotification)),
+        )
+
+        // Report failed tracking attempts to Sentry
+        results.forEach((r, i) => {
+          if (r.status === 'rejected') {
+            captureException(r.reason, {
+              extra: {
+                sawp: swaps[i],
+              },
+              tags: {
+                source: 'useChainflipTracker',
+              },
+              level: 'error',
+            })
+          }
+        })
+        // no catch needed
+      } finally {
+        isPollingRef.current = false
+      }
+    },
+    [updateStatus, addCompletedTransfer, remove, addNotification],
+  )
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: we only care about chainflipSwaps length not content
+  useEffect(() => {
+    if (chainflipSwaps.length === 0) return
+
+    // immediate
+    pollStatuses(chainflipSwaps)
+
+    // then poll every 20s
+    const interval = setInterval(() => pollStatuses(chainflipSwaps), 20_000)
+    return () => clearInterval(interval)
+  }, [chainflipSwaps.length, pollStatuses])
+}

--- a/app/src/hooks/useChainflipTracker.ts
+++ b/app/src/hooks/useChainflipTracker.ts
@@ -146,7 +146,6 @@ export const useChainflipTracker = (ongoingTransfers: StoredTransfer[]): void =>
     [updateStatus, addCompletedTransfer, remove, addNotification, updateProgress],
   )
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: we only care about chainflipSwaps length not content
   useEffect(() => {
     if (chainflipSwaps.length === 0) return
 
@@ -156,5 +155,5 @@ export const useChainflipTracker = (ongoingTransfers: StoredTransfer[]): void =>
     // then poll every 20s
     const interval = setInterval(() => pollStatuses(chainflipSwaps), 20_000)
     return () => clearInterval(interval)
-  }, [chainflipSwaps.length, pollStatuses])
+  }, [chainflipSwaps, pollStatuses])
 }

--- a/app/src/hooks/useOngoingTransfers.ts
+++ b/app/src/hooks/useOngoingTransfers.ts
@@ -6,8 +6,9 @@ const useOngoingTransfers = () => {
   const remove = useOngoingTransfersStore.getState().remove
   const updateUniqueId = useOngoingTransfersStore.getState().updateUniqueId
   const updateStatus = useOngoingTransfersStore.getState().updateStatus
+  const updateProgress = useOngoingTransfersStore.getState().updateProgress
 
-  return { ongoingTransfers, addOrUpdate, remove, updateUniqueId, updateStatus }
+  return { ongoingTransfers, addOrUpdate, remove, updateUniqueId, updateStatus, updateProgress }
 }
 
 export default useOngoingTransfers

--- a/app/src/hooks/useTransferProgress.ts
+++ b/app/src/hooks/useTransferProgress.ts
@@ -1,14 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { StoredTransfer } from '@/models/transfer'
 import { Direction } from '@/services/transfer'
+import { isChainflipSwap } from '@/utils/chainflip'
 
 const ESTIMATED_DURATION = {
   toEthereum: 2 * 60 * 60, // 2 h in seconds
   toPolkadot: 30 * 60, // 30mins in seconds
   xcmTransfer: 30, // 30 seconds
+  chainflipSwap: 5 * 60, // 5 mins (~2mins local transfer + ~3mins swap)
 }
 
-const getDurationEstimateMs = (direction: Direction) => {
+const getDurationEstimateMs = (direction: Direction, isChainflipSwap: boolean) => {
+  if (isChainflipSwap) return ESTIMATED_DURATION.chainflipSwap * 1000
   switch (direction) {
     case Direction.ToEthereum:
       return ESTIMATED_DURATION.toEthereum * 1000
@@ -22,9 +25,14 @@ const getDurationEstimateMs = (direction: Direction) => {
   }
 }
 
-const getTransferProgress = (date: Date, direction: Direction, shouldStartProgress: boolean) => {
+const getTransferProgress = (
+  date: Date,
+  direction: Direction,
+  shouldStartProgress: boolean,
+  isChainflipSwap: boolean,
+) => {
   if (!shouldStartProgress) return 0
-  const estimatedDurationMs = getDurationEstimateMs(direction)
+  const estimatedDurationMs = getDurationEstimateMs(direction, isChainflipSwap)
   const transferTimestamp = new Date(date).getTime()
   const targetTimestamp = estimatedDurationMs + transferTimestamp
   const currentTimestamp = Date.now()
@@ -40,31 +48,42 @@ const getTransferProgress = (date: Date, direction: Direction, shouldStartProgre
   return Math.min(progress + 1, 90)
 }
 
+const getTransferDate = (transfer: StoredTransfer, isChainflipSwap: boolean) => {
+  // handles chainflip swaps
+  if (isChainflipSwap) return transfer.date
+  // Bridges, XCMs, Hydra swaps, etc
+  return transfer.finalizedAt ? transfer.finalizedAt : transfer.date
+}
+
 export default function useTransferProgress(transfer: StoredTransfer, direction: Direction) {
-  const transferDate = transfer.finalizedAt ? transfer.finalizedAt : transfer.date
+  const isChainflip = !!(
+    transfer.destinationToken &&
+    isChainflipSwap(transfer.sourceChain, transfer.destChain, transfer.sourceToken, transfer.destinationToken)
+  )
+  const transferDate = getTransferDate(transfer, isChainflip)
   const shouldStartProgress = !!(
     direction !== Direction.WithinPolkadot ||
     (direction === Direction.WithinPolkadot && transfer.finalizedAt)
   )
   const [progress, setProgress] = useState<number>(
     // Calculate progress from cache if transferStatus is available
-    getTransferProgress(transferDate, direction, shouldStartProgress),
+    getTransferProgress(transferDate, direction, shouldStartProgress, isChainflip),
   )
   const progressIntervalRef = useRef<NodeJS.Timeout | null>(null)
 
   const updateProgress = useCallback(() => {
-    const transferProgress = getTransferProgress(transferDate, direction, shouldStartProgress)
+    const transferProgress = getTransferProgress(transferDate, direction, shouldStartProgress, isChainflip)
     setProgress(transferProgress)
     if (transferProgress >= 90 && progressIntervalRef.current) {
       clearInterval(progressIntervalRef.current)
       progressIntervalRef.current = null
     }
-  }, [transferDate, direction, shouldStartProgress])
+  }, [transferDate, direction, shouldStartProgress, isChainflip])
 
   useEffect(() => {
-    const intervalDuration = direction === Direction.WithinPolkadot ? 1500 : 5000
+    const intervalDuration = direction === Direction.WithinPolkadot || isChainflip ? 1500 : 5000
     // Initiate the progress bar without waiting the timeout.
-    if (progress === 0) setProgress(getTransferProgress(transferDate, direction, shouldStartProgress))
+    if (progress === 0) setProgress(getTransferProgress(transferDate, direction, shouldStartProgress, isChainflip))
     // Set a time-interval to update the progress bar
     progressIntervalRef.current = setInterval(updateProgress, intervalDuration)
 
@@ -74,7 +93,7 @@ export default function useTransferProgress(transfer: StoredTransfer, direction:
         clearInterval(progressIntervalRef.current)
       }
     }
-  }, [transferDate, direction, progress, shouldStartProgress, updateProgress])
+  }, [transferDate, direction, progress, shouldStartProgress, updateProgress, isChainflip])
 
   return progress
 }

--- a/app/src/models/transfer.ts
+++ b/app/src/models/transfer.ts
@@ -34,6 +34,7 @@ export interface StoredTransfer extends RawTransfer {
   status?: string
   // WithinPolkadot transfer is considered as finalized
   finalizedAt?: Date
+  progress?: number
   swapInformation?: {
     currentStep?: number
     plan?: TRouterPlan

--- a/app/src/store/ongoingTransfersStore.ts
+++ b/app/src/store/ongoingTransfersStore.ts
@@ -12,6 +12,7 @@ interface State {
   addOrUpdate: (transfer: StoredTransfer) => void
   updateUniqueId: (id: string, uniqueTrackingId: string) => void
   updateStatus: (id: string, newStatus?: string) => void
+  updateProgress: (id: string) => void
   remove: (id: string) => void
 }
 
@@ -79,6 +80,21 @@ export const useOngoingTransfersStore = create<State>()(
               : transfer,
           ),
         }))
+      },
+
+      // When called, this function completes the transfer progress bar
+      updateProgress: (id: string) => {
+        if (!id) return
+        set(state => {
+          return {
+            transfers: state.transfers.map(transfer => {
+              if (transfer.id === id) {
+                transfer.progress = 100
+              }
+              return transfer
+            }),
+          }
+        })
       },
 
       remove: id => {

--- a/app/src/store/ongoingTransfersStore.ts
+++ b/app/src/store/ongoingTransfersStore.ts
@@ -11,7 +11,7 @@ interface State {
   // Actions
   addOrUpdate: (transfer: StoredTransfer) => void
   updateUniqueId: (id: string, uniqueTrackingId: string) => void
-  updateStatus: (id: string) => void
+  updateStatus: (id: string, newStatus?: string) => void
   remove: (id: string) => void
 }
 
@@ -66,14 +66,14 @@ export const useOngoingTransfersStore = create<State>()(
         }))
       },
 
-      updateStatus: (id: string) => {
+      updateStatus: (id: string, newStatus?: string) => {
         if (!id) return
         set(state => ({
           transfers: state.transfers.map(transfer =>
             transfer.id === id
               ? {
                   ...transfer,
-                  status: `Arriving at ${transfer.destChain.name}`,
+                  status: newStatus ? newStatus : `Arriving at ${transfer.destChain.name}`,
                   finalizedAt: new Date(),
                 }
               : transfer,


### PR DESCRIPTION
<!-- PR Title format: feat|fix|chore|refactor|test: short summary (e.g. feat: add aave snowbridge transfers) -->

## Description
This PR handles tracking a transfer from Ongoing to Completed:

✅ Implements Chainflip swaps tracking (`useChainflipTracker()` hook)
✅ Gets the [Chainflip explorer](https://scan.chainflip.io/swaps)
✅ Add swap to analytics with `trackTransferMetrics()` & `updateTransferMetrics()`
✅ Updates progress bar status. It introduces a 1.5-second timeout to complete the progress bar to 100%.

## Related Issue
Closes [VEL-445](https://linear.app/velocitylabs/issue/VEL-445/chainflip-swap-tracking-explorer-links-metrics-support-and-progressbar)