### PR TITLE
feat: implement local transfer fees to Chainflip deposit address

### DIFF
--- a/app/src/hooks/useFees.ts
+++ b/app/src/hooks/useFees.ts
@@ -82,7 +82,7 @@ export default function useFees(params: UseFeesParams) {
     address: isBridgingToEthereum ? senderAddress : undefined,
   })
 
-  const { chainflipQuote, isLoadingChainflipQuote, isChainflipQuoteError } = useChainflipQuote({
+  const { chainflipQuote, isChainflipQuoteError } = useChainflipQuote({
     sourceChain,
     destinationChain,
     sourceToken: sourceToken,
@@ -450,7 +450,6 @@ export default function useFees(params: UseFeesParams) {
     destinationChain,
     sourceToken,
     chainflipQuote,
-    isLoadingChainflipQuote,
     isChainflipQuoteError,
     snowbridgeContext,
     addNotification,
@@ -565,11 +564,9 @@ const getEip1559NetworkFee = async (
   sourceToken: Token,
   sourceTokenAmount: number,
 ): Promise<{ estimatedGasFee: bigint; isBalanceSufficient: boolean }> => {
-  if (!publicClient || !walletClient) throw new Error('Public client or wallet client not found')
-
   let gas: bigint
 
-  if (sourceToken === EthereumTokens.ETH) {
+  if (sourceToken.id === EthereumTokens.ETH.id) {
     gas = await publicClient.estimateGas({
       account: walletClient.account,
       to: senderAddress, // Recipient here must be a placeholder address so we use the sender address
@@ -615,8 +612,6 @@ const checkEip1559BalanceSufficiency = async (
   sourceTokenAmount: number,
   address: `0x${string}`,
 ): Promise<boolean> => {
-  if (!publicClient) throw new Error('Public client not found')
-
   const feesValues = await publicClient.estimateFeesPerGas()
   const maxFeePerGas = feesValues.maxFeePerGas ?? gasPrice
   const maxGasFee = gas * maxFeePerGas

--- a/app/src/hooks/useFees.ts
+++ b/app/src/hooks/useFees.ts
@@ -353,7 +353,8 @@ export default function useFees(params: UseFeesParams) {
           const feeList: FeeDetails[] = [...chainflipfeeList]
 
           if (sourceChain.network === 'Polkadot') {
-            const feeTokenInDollars = (await getCachedTokenPrice(sourceToken))?.usd ?? 0
+            const localTransferfeeToken = PolkadotTokens.DOT
+            const feeTokenInDollars = (await getCachedTokenPrice(localTransferfeeToken))?.usd ?? 0
             const localTransferParams = {
               sourceChain,
               destinationChain: sourceChain, // Local transfer to AH
@@ -369,11 +370,11 @@ export default function useFees(params: UseFeesParams) {
             feeList.unshift({
               title: 'Transfer fees',
               chain: sourceChain,
-              sufficient: originFee.sufficient ? 'sufficient' : 'insufficient', // Should I check balance here?
+              sufficient: originFee.sufficient ? 'sufficient' : 'insufficient',
               amount: {
                 amount: originFee.fee,
-                token: sourceToken,
-                inDollars: feeTokenInDollars ? toHuman(originFee.fee, sourceToken) * feeTokenInDollars : 0,
+                token: localTransferfeeToken,
+                inDollars: feeTokenInDollars ? toHuman(originFee.fee, localTransferfeeToken) * feeTokenInDollars : 0,
               },
             })
           }

--- a/app/src/hooks/useFees.ts
+++ b/app/src/hooks/useFees.ts
@@ -623,7 +623,7 @@ const checkEip1559BalanceSufficiency = async (
   const ethBalance = await publicClient.getBalance({ address })
 
   // ETH balance check
-  if (sourceToken === EthereumTokens.ETH) {
+  if (sourceToken.id === EthereumTokens.ETH.id) {
     const transferAmount = parseEther(sourceTokenAmount.toString())
     return ethBalance >= transferAmount + maxGasFee
   }

--- a/app/src/hooks/useFees.ts
+++ b/app/src/hooks/useFees.ts
@@ -338,7 +338,7 @@ export default function useFees(params: UseFeesParams) {
             setIsBalanceSufficientForFees(true) // TODO: check if this is correct
             break
           }
-          setLoading(isLoadingChainflipQuote)
+          setLoading(true)
 
           const chainflipfeeList: FeeDetails[] = await Promise.all(
             chainflipQuote.includedFees.map(async fee => {

--- a/app/src/models/transfer.ts
+++ b/app/src/models/transfer.ts
@@ -202,6 +202,7 @@ export type FeeDetailType =
   | 'Swap fees'
   | 'Broker fees'
   | 'Deposit fees'
+  | 'Transfer fees'
 
 export type FeeSufficiency = 'sufficient' | 'insufficient' | 'undetermined'
 


### PR DESCRIPTION
<!-- PR Title format: feat|fix|chore|refactor|test: short summary (e.g. feat: add aave snowbridge transfers) -->

## Description
- Adds the local transfer fee ETH > ETH Chainflip deposit address, and AH > AH Chainflip deposit address
- Fetches fees and, adds it to the fee array
- Verifies balance against this fee

## Related Issue
Closes [VEL-493](https://linear.app/velocitylabs/issue/VEL-493/chainflip-update-usefees-to-handle-local-transfer-to-deposit-address)