### PR TITLE
fix: Chainflip loading fee UI glitch

### DIFF
--- a/app/src/components/Transfer.tsx
+++ b/app/src/components/Transfer.tsx
@@ -129,13 +129,28 @@ export default function Transfer() {
     owner: sourceWallet?.sender?.address,
   })
 
-  const { chainflipQuote, isChainflipQuoteError, chainflipQuoteError } = useChainflipQuote({
-    sourceChain,
-    destinationChain,
-    sourceToken: sourceTokenAmount?.token,
-    destinationToken: destinationTokenAmount?.token,
-    amount: safeConvertAmount(sourceTokenAmount?.amount, sourceTokenAmount?.token)?.toString() ?? '0',
-  })
+  const { isChainflipSwap, chainflipQuote, isLoadingChainflipQuote, isChainflipQuoteError, chainflipQuoteError } =
+    useChainflipQuote({
+      sourceChain,
+      destinationChain,
+      sourceToken: sourceTokenAmount?.token,
+      destinationToken: destinationTokenAmount?.token,
+      amount: safeConvertAmount(sourceTokenAmount?.amount, sourceTokenAmount?.token)?.toString() ?? '0',
+    })
+
+  const isChainflipSwapAllowed = useMemo(() => {
+    if (
+      // Transfer is not a Chainflip swap
+      !isChainflipSwap ||
+      // if Chainflip swap is loading or if swap quote is avaialble & valid
+      (isChainflipSwap && isLoadingChainflipQuote) ||
+      (isChainflipSwap && !isChainflipQuoteError && !!chainflipQuote)
+    )
+      return true
+
+    // If conditions are not met, the swap is not allowed
+    return false
+  }, [isChainflipSwap, isLoadingChainflipQuote, isChainflipQuoteError, chainflipQuote])
 
   const requiresErc20SpendApproval =
     erc20SpendAllowance !== undefined && erc20SpendAllowance < sourceTokenAmount!.amount!
@@ -178,6 +193,7 @@ export default function Transfer() {
     // Default duration from direction
     return direction ? getDurationEstimate(direction) : undefined
   }
+
   const hasFees = fees && fees?.length > 0
   const allFeesItemsAreSufficient = hasFees && fees.every(fee => fee.sufficient !== 'insufficient')
 
@@ -214,7 +230,7 @@ export default function Transfer() {
     destinationChain &&
     sourceWallet?.sender &&
     destinationWallet?.sender &&
-    !isChainflipQuoteError
+    isChainflipSwapAllowed
 
   const shouldDisplayUsdtRevokeAllowance =
     erc20SpendAllowance !== 0 && sourceTokenAmount?.token?.id === EthereumTokens.USDT.id
@@ -478,7 +494,7 @@ export default function Transfer() {
       <AnimatePresence>
         {shouldDisplayTxSummary && (
           <TxSummary
-            loading={loadingFees}
+            loading={loadingFees || isLoadingChainflipQuote}
             sourceTokenAmount={sourceTokenAmount}
             destinationTokenAmount={destinationTokenAmount}
             destChain={destinationChain}

--- a/app/src/hooks/useChainflipQuote.ts
+++ b/app/src/hooks/useChainflipQuote.ts
@@ -1,6 +1,7 @@
 import { captureException } from '@sentry/nextjs'
 import { useQuery } from '@tanstack/react-query'
 import type { Chain, Token } from '@velocitylabs-org/turtle-registry'
+import { useMemo } from 'react'
 import { getChainflipQuote, isChainflipSwap } from '@/utils/chainflip'
 
 export interface ChainflipQuoteParams {
@@ -58,7 +59,13 @@ export const useChainflipQuote = (params: ChainflipQuoteParams) => {
     retry: 2,
   })
 
+  const isChainflip = useMemo(
+    () => isChainflipSwap(params.sourceChain, params.destinationChain, params.sourceToken, params.destinationToken),
+    [params.sourceChain, params.destinationChain, params.sourceToken, params.destinationToken],
+  )
+
   return {
+    isChainflipSwap: isChainflip,
     chainflipQuote,
     isLoadingChainflipQuote: isLoadingChainflipQuote || isFetchingChainflipQuote,
     isChainflipQuoteError,

--- a/app/src/utils/chainflip.ts
+++ b/app/src/utils/chainflip.ts
@@ -270,11 +270,13 @@ export const getChainflipAsset = async (asset: Token, chainflipChain: ChainData)
 
 /** Check if the swap is supported by Chainflip and match our Chainflip routes registry. */
 export const isChainflipSwap = (
-  sourceChain: Chain,
-  destinationChain: Chain,
-  sourceToken: Token,
-  destinationToken: Token,
+  sourceChain?: Chain | null,
+  destinationChain?: Chain | null,
+  sourceToken?: Token | null,
+  destinationToken?: Token | null,
 ): boolean => {
+  if (!sourceChain || !destinationChain || !sourceToken || !destinationToken) return false
+
   return chainflipRoutes.some(
     route =>
       route.from.chainId === sourceChain.chainId &&
@@ -284,9 +286,7 @@ export const isChainflipSwap = (
 }
 
 export const getChainflipOngoingSwaps = (ongoingTransfers: StoredTransfer[]) => {
-  return ongoingTransfers.filter(
-    t => t.destinationToken && isChainflipSwap(t.sourceChain, t.destChain, t.sourceToken, t.destinationToken),
-  )
+  return ongoingTransfers.filter(t => isChainflipSwap(t.sourceChain, t.destChain, t.sourceToken, t.destinationToken))
 }
 
 /** Check if the amount is greater than the minimum swap amount for the asset. */


### PR DESCRIPTION
<!-- PR Title format: feat|fix|chore|refactor|test: short summary (e.g. feat: add aave snowbridge transfers) -->

## Description
Fix glitch (introduced after the new Tx Summary) when Chainflip fees are loading.

## Related Issue
Closes [VEL-496](https://linear.app/velocitylabs/issue/VEL-496/chainflip-fix-ui-glitch-when-fees-are-loading)