### PR TITLE
Fix: Add missing destination token amount to chainflip swaps

### DIFF
--- a/app/src/components/ongoing/OngoingTransactionCard.tsx
+++ b/app/src/components/ongoing/OngoingTransactionCard.tsx
@@ -19,8 +19,6 @@ interface OngoingTransactionCardProps {
 }
 
 export default function OngoingTransactionCard({ direction, transfer, status }: OngoingTransactionCardProps) {
-  console.log(transfer)
-
   return (
     <div className="mb-2 rounded-[16px] border border-turtle-level3 p-3 hover:cursor-pointer">
       <div className="mb-2 flex items-center justify-between">

--- a/app/src/hooks/useChainflipApi.ts
+++ b/app/src/hooks/useChainflipApi.ts
@@ -63,6 +63,7 @@ const useChainflipApi = () => {
       destinationChain,
       sourceToken,
       destinationToken,
+      destinationAmount,
       sourceAmount,
       sender,
       recipient,
@@ -100,18 +101,20 @@ const useChainflipApi = () => {
 
           const senderAddress = await getSenderAddress(sender)
           const sourceTokenUSDValue = (await getCachedTokenPrice(sourceToken))?.usd ?? 0
-          const destinationTokenUSDValue = (await getCachedTokenPrice(params.destinationToken))?.usd ?? 0
+          const destinationTokenUSDValue = (await getCachedTokenPrice(destinationToken))?.usd ?? 0
           const date = new Date()
 
           addOrUpdate({
             id: txHash.toString(),
             sourceChain,
             sourceToken,
-            destinationToken: destinationToken,
-            sourceTokenUSDValue,
-            sender: senderAddress,
-            destChain: destinationChain,
             sourceAmount: sourceAmount.toString(),
+            sourceTokenUSDValue,
+            destChain: destinationChain,
+            destinationToken,
+            destinationAmount: destinationAmount?.toString(),
+            destinationTokenUSDValue,
+            sender: senderAddress,
             recipient,
             date,
             fees,
@@ -251,7 +254,8 @@ const submitPolkadotTransfer = async (
   removeOngoingTransfer: (id: string) => void,
   addNotification: (notification: Omit<Notification, 'id'>) => void,
 ): Promise<void> => {
-  const { sourceChain, sourceToken, sender, destinationToken, sourceAmount, fees, onComplete } = polkadotTransferParams
+  const { sourceChain, sourceToken, sender, destinationToken, destinationAmount, sourceAmount, fees, onComplete } =
+    polkadotTransferParams
   const { destinationChain, recipient } = swapParams
 
   // Here we create the unsigned transaction with Paraspell Builder
@@ -268,13 +272,15 @@ const submitPolkadotTransfer = async (
     id: '',
     sourceChain,
     sourceToken,
-    destinationToken,
+    sourceAmount: sourceAmount.toString(),
     sourceTokenUSDValue,
-    sender: formattedSenderAddress,
     // We use the final destinationChain from the swapParams (ex: ETH)
     // not the polkadotTransferParams.destinationChain (ex: AssetHub)
     destChain: destinationChain,
-    sourceAmount: sourceAmount.toString(),
+    destinationToken,
+    destinationAmount: destinationAmount?.toString(),
+    destinationTokenUSDValue,
+    sender: formattedSenderAddress,
     // We use the final recipient from the swapParams (ex: ETH)
     // not the chainflip deposit address
     recipient: recipient,


### PR DESCRIPTION
<!-- PR Title format: feat|fix|chore|refactor|test: short summary (e.g. feat: add aave snowbridge transfers) -->

## Description
Displays both swapped tokens (Logo & Amount)

## Related Issue
Linked to VEL-499