### PR TITLE
Fix: Add guards to safeConvertAmount in useFees

### DIFF
--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -17,7 +17,8 @@ import { isSameChain } from './routes'
  * Safe version of `convertAmount` that handles `null` and `undefined` params
  */
 export const safeConvertAmount = (input?: number | null, token?: Token | null): bigint | null => {
-  if (input == null || !token) return null
+  if (input == null || Number.isNaN(input) || !Number.isFinite(input) || !token || !Number.isInteger(token.decimals))
+    return null
 
   return BigInt(Math.floor(input * 10 ** token.decimals))
 }


### PR DESCRIPTION
<!-- PR Title format: feat|fix|chore|refactor|test: short summary (e.g. feat: add aave snowbridge transfers) -->

## Description
This PR prevents `isNaN` error in `safeConvertAmount(sourceTokenAmount, sourceToken)`. 
⚠️ Can't reproduce the [Sentry related error](https://velocity-labs.sentry.io/issues/64113211/?project=4507345235345488&referrer=github-pr-bot)

## Related Issue
Closes [VEL-507](https://linear.app/velocitylabs/issue/VEL-507/investigates-and-fix-usefees-isnan)