### PR TITLE
Fix: Error 500 when swaps params are unavailable in History

### DIFF
--- a/app/src/components/completed/TransactionCard.tsx
+++ b/app/src/components/completed/TransactionCard.tsx
@@ -1,4 +1,3 @@
-import type { Token } from '@velocitylabs-org/turtle-registry'
 import { colors } from '@velocitylabs-org/turtle-tailwind-config'
 import { cn, TokenLogo } from '@velocitylabs-org/turtle-ui'
 import Image from 'next/image'
@@ -47,10 +46,10 @@ export default function TransactionCard({ tx }: TransactionCardProps) {
                 transferFailed && 'text-turtle-error',
               )}
             >
-              {isSwap ? (
+              {isSwap && tx.destinationAmount && tx.destinationToken ? (
                 <>
-                  <span>{formatAmount(toHuman(tx.destinationAmount as string, tx.destinationToken as Token))}</span>
-                  <TokenLogo token={tx.destinationToken as Token} sourceChain={tx.destChain} size={25} />
+                  <span>{formatAmount(toHuman(tx.destinationAmount, tx.destinationToken))}</span>
+                  <TokenLogo token={tx.destinationToken} sourceChain={tx.destChain} size={25} />
                 </>
               ) : (
                 <>

--- a/app/src/components/completed/TransactionDialog.tsx
+++ b/app/src/components/completed/TransactionDialog.tsx
@@ -1,4 +1,3 @@
-import type { Token } from '@velocitylabs-org/turtle-registry'
 import { colors } from '@velocitylabs-org/turtle-tailwind-config'
 import { cn, Icon, TokenLogo } from '@velocitylabs-org/turtle-ui'
 import ChainflipRefund from '@/components/ChainflipRefund'
@@ -74,11 +73,11 @@ export default function TransactionDialog({ tx }: TransactionDialogProps) {
             >
               <span>{formatAmount(toHuman(tx.sourceAmount, tx.sourceToken))}</span>
               <TokenLogo token={tx.sourceToken} sourceChain={tx.sourceChain} size={35} />
-              {isSwap && (
+              {isSwap && tx.destinationAmount && tx.destinationToken && (
                 <>
                   <ArrowRight className="h-3 w-3" fill={getSVGColor(tx.result)} />
-                  <span>{formatAmount(toHuman(tx.destinationAmount as string, tx.destinationToken as Token))}</span>
-                  <TokenLogo token={tx.destinationToken as Token} sourceChain={tx.destChain} size={35} />
+                  <span>{formatAmount(toHuman(tx.destinationAmount, tx.destinationToken))}</span>
+                  <TokenLogo token={tx.destinationToken} sourceChain={tx.destChain} size={35} />
                 </>
               )}
             </h3>
@@ -160,16 +159,15 @@ export default function TransactionDialog({ tx }: TransactionDialogProps) {
                 }
               />
 
-              {isSwap && (
+              {isSwap && tx.destinationAmount && tx.destinationToken && (
                 <SummaryRow
                   label="Amount Received"
-                  amount={formatAmount(toHuman(tx.destinationAmount as string, tx.destinationToken as Token), 'Long')}
-                  symbol={tx.destinationToken?.symbol as string}
+                  amount={formatAmount(toHuman(tx.destinationAmount, tx.destinationToken), 'Long')}
+                  symbol={tx.destinationToken.symbol}
                   usdValue={
                     typeof tx.destinationTokenUSDValue === 'number'
                       ? formatAmount(
-                          toHuman(tx.destinationAmount as string, tx.destinationToken as Token) *
-                            (tx.destinationTokenUSDValue ?? 0),
+                          toHuman(tx.destinationAmount, tx.destinationToken) * (tx.destinationTokenUSDValue ?? 0),
                           'Long',
                         )
                       : undefined

--- a/app/src/components/ongoing/OngoingTransactionCard.tsx
+++ b/app/src/components/ongoing/OngoingTransactionCard.tsx
@@ -1,4 +1,3 @@
-import type { Token } from '@velocitylabs-org/turtle-registry'
 import { colors } from '@velocitylabs-org/turtle-tailwind-config'
 import { TokenLogo } from '@velocitylabs-org/turtle-ui'
 import Image from 'next/image'
@@ -39,10 +38,10 @@ export default function OngoingTransactionCard({ direction, transfer, status }: 
           color={colors['turtle-secondary']}
         />
         <div className="no-letter-spacing text-xl font-normal text-turtle-foreground">
-          {isSwap ? (
+          {isSwap && transfer.destinationAmount && transfer.destinationToken ? (
             <span className="flex items-center gap-1">
-              {formatAmount(toHuman(transfer.destinationAmount as string, transfer.destinationToken as Token))}{' '}
-              <TokenLogo token={transfer.destinationToken as Token} sourceChain={transfer.destChain} size={25} />
+              {formatAmount(toHuman(transfer.destinationAmount, transfer.destinationToken))}{' '}
+              <TokenLogo token={transfer.destinationToken} sourceChain={transfer.destChain} size={25} />
             </span>
           ) : (
             <span className="flex items-center gap-1">

--- a/app/src/components/ongoing/OngoingTransactionDialog.tsx
+++ b/app/src/components/ongoing/OngoingTransactionDialog.tsx
@@ -1,4 +1,3 @@
-import type { Token } from '@velocitylabs-org/turtle-registry'
 import { colors } from '@velocitylabs-org/turtle-tailwind-config'
 import { Icon, TokenLogo } from '@velocitylabs-org/turtle-ui'
 import { useCallback } from 'react'
@@ -86,11 +85,11 @@ export default function OngoingTransactionDialog({ transfer, status }: OngoingTr
               <span>{formatAmount(sourceAmountHuman, 'Long')}</span>
               <TokenLogo token={transfer.sourceToken} sourceChain={transfer.sourceChain} size={35} />
 
-              {isSwap && (
+              {isSwap && transfer.destinationToken && (
                 <>
                   <ArrowRight className="h-3 w-3" fill={colors['turtle-secondary-dark']} />
                   <span>{formatAmount(destinationAmountHuman, 'Long')}</span>
-                  <TokenLogo token={transfer.destinationToken as Token} sourceChain={transfer.destChain} size={35} />
+                  <TokenLogo token={transfer.destinationToken} sourceChain={transfer.destChain} size={35} />
                 </>
               )}
             </h3>
@@ -145,11 +144,11 @@ export default function OngoingTransactionDialog({ transfer, status }: OngoingTr
                 usdValue={formatAmount(sourceAmountUSD, 'Long')}
               />
 
-              {isSwap && (
+              {isSwap && transfer.destinationToken && (
                 <SummaryRow
                   label="Amount Received"
                   amount={formatAmount(destinationAmountHuman, 'Long')}
-                  symbol={transfer.destinationToken?.symbol as string}
+                  symbol={transfer.destinationToken.symbol}
                   usdValue={formatAmount(destinationAmountUSD, 'Long')}
                 />
               )}

--- a/app/src/components/ongoing/OngoingTransactionDialog.tsx
+++ b/app/src/components/ongoing/OngoingTransactionDialog.tsx
@@ -32,9 +32,10 @@ export default function OngoingTransactionDialog({ transfer, status }: OngoingTr
     isPolkadotSwap(transfer) ||
     isChainflipSwap(transfer.sourceChain, transfer.destChain, transfer.sourceToken, transfer.destinationToken)
 
-  const destinationAmountHuman = isSwap
-    ? toHuman(transfer.destinationAmount as string, transfer.destinationToken as Token)
-    : 0
+  const destinationAmountHuman =
+    isSwap && transfer.destinationAmount && transfer.destinationToken
+      ? toHuman(transfer.destinationAmount, transfer.destinationToken)
+      : 0
   const destinationAmountUSD = destinationAmountHuman * (transfer.destinationTokenUSDValue ?? 0)
 
   const getStatus = useCallback(

--- a/app/src/hooks/useChainflipApi.ts
+++ b/app/src/hooks/useChainflipApi.ts
@@ -303,7 +303,7 @@ const submitPolkadotTransfer = async (
             setStatus('Idle')
 
             trackTransferMetrics({
-              transferParams: polkadotTransferParams,
+              transferParams: swapParams,
               txId: event.txHash?.toString(),
               senderAddress: formattedSenderAddress,
               sourceTokenUSDValue,


### PR DESCRIPTION
<!-- PR Title format: feat|fix|chore|refactor|test: short summary (e.g. feat: add aave snowbridge transfers) -->

## Description
This PR prevents the app from crashing when swap params are unavailable in the user's `local storage`/history. 
⚠️ Since it works for me and I can't manually update my transfer history, those fixes are based on assumptions.

## Related Issue
Closes [VEL-505](https://linear.app/velocitylabs/issue/VEL-505/investigates-and-fix-ongoing-transfers-errors)