### PR TITLE
Fix: AH max button for Chainflip Swaps

### DIFF
--- a/app/src/hooks/useTransferForm.ts
+++ b/app/src/hooks/useTransferForm.ts
@@ -265,12 +265,13 @@ const useTransferForm = () => {
           return
         }
 
+        const isSwap = isChainflipSwap(sourceChain, destinationChain, sourceToken, destToken)
         const recipient = getRecipientAddress(manualRecipient, destinationWallet) ?? destinationWallet.sender.address
         const params = {
           sourceChain,
-          destinationChain,
+          destinationChain: isSwap ? sourceChain : destinationChain, // Handle chainflip local transfer from AH
           sourceToken: sourceTokenAmount.token,
-          recipient,
+          recipient: isSwap ? sourceWallet.sender.address : recipient, // Handle chainflip local transfer from AH
           sender: sourceWallet.sender,
           sourceAmount: balanceData.value,
         }
@@ -322,6 +323,7 @@ const useTransferForm = () => {
     sourceToken,
     sourceWallet?.sender,
     addNotification,
+    destToken,
   ])
 
   const onSubmit: SubmitHandler<FormInputs> = useCallback(


### PR DESCRIPTION
<!-- PR Title format: feat|fix|chore|refactor|test: short summary (e.g. feat: add aave snowbridge transfers) -->

## Description
Max amount `btn` requires tweaking the `destination chain` & the `recipient` to match the local transfer expected params.

## Related Issue
Closes [VEL-508](https://linear.app/velocitylabs/issue/VEL-508/fix-assethub-max-amount-for-chainflip-swaps)