### PR TITLE
Fix: txhash format tohex

### DIFF
--- a/.changeset/social-mangos-itch.md
+++ b/.changeset/social-mangos-itch.md
@@ -1,0 +1,5 @@
+---
+"@velocitylabs-org/turtle-widget": patch
+---
+
+fix txhash format

--- a/app/src/hooks/useChainflipApi.ts
+++ b/app/src/hooks/useChainflipApi.ts
@@ -16,7 +16,7 @@ import { getChainSpecificAddress, getSenderAddress } from '@/utils/address'
 import { trackTransferMetrics, updateTransferMetrics } from '@/utils/analytics'
 import { type ChainflipQuote, getDepositAddress, getRequiredBlockConfirmation } from '@/utils/chainflip'
 import { extractPapiEvent, getPolkadotSigner } from '@/utils/papi'
-import { convertAmount, txWasCancelled } from '@/utils/transfer'
+import { convertAmount, hashToHex, txWasCancelled } from '@/utils/transfer'
 import { addToOngoingTransfers } from '@/utils/transferTracking'
 import useNotification from './useNotification'
 import useOngoingTransfers from './useOngoingTransfers'
@@ -296,7 +296,7 @@ const submitPolkadotTransfer = async (
     unsignedTx.signSubmitAndWatch(polkadotSigner).subscribe({
       next: async (event: TxEvent) => {
         try {
-          transferToStore.id = event.txHash?.toString()
+          transferToStore.id = hashToHex(event.txHash)
 
           const onSignedCallback = () => {
             onComplete?.()
@@ -304,7 +304,7 @@ const submitPolkadotTransfer = async (
 
             trackTransferMetrics({
               transferParams: swapParams,
-              txId: event.txHash?.toString(),
+              txId: hashToHex(event.txHash),
               senderAddress: formattedSenderAddress,
               sourceTokenUSDValue,
               destinationTokenUSDValue,
@@ -316,7 +316,7 @@ const submitPolkadotTransfer = async (
           await handlePolkadotTxEvents(event, addOrUpdate, transferToStore, resolve, onSignedCallback)
         } catch (error) {
           xcmTransferBuilderManager.disconnect(polkadotTransferParams)
-          handleSendError(sender, error, removeOngoingTransfer, addNotification, setStatus, event.txHash?.toString())
+          handleSendError(sender, error, removeOngoingTransfer, addNotification, setStatus, hashToHex(event.txHash))
           reject(error instanceof Error ? error : new Error(String(error)))
         }
       },

--- a/app/src/hooks/useParaspellApi.ts
+++ b/app/src/hooks/useParaspellApi.ts
@@ -19,7 +19,7 @@ import { getSenderAddress } from '@/utils/address'
 import { trackTransferMetrics, updateTransferMetrics } from '@/utils/analytics'
 import { extractPapiEvent } from '@/utils/papi'
 import type { DryRunResult } from '@/utils/paraspellTransfer'
-import { getExplorerLink, isSameChainSwap, isSwapWithTransfer, txWasCancelled } from '@/utils/transfer'
+import { getExplorerLink, hashToHex, isSameChainSwap, isSwapWithTransfer, txWasCancelled } from '@/utils/transfer'
 import useCompletedTransfers from './useCompletedTransfers'
 import useNotification from './useNotification'
 import useOngoingTransfers from './useOngoingTransfers'
@@ -152,7 +152,7 @@ const useParaspellApi = () => {
     tx.signSubmitAndWatch(polkadotSigner).subscribe({
       next: async (event: TxEvent) => {
         const transferToStore = {
-          id: event.txHash?.toString() ?? '',
+          id: hashToHex(event.txHash),
           sourceChain: params.sourceChain,
           sourceToken: params.sourceToken,
           destinationToken: params.destinationToken,
@@ -172,7 +172,7 @@ const useParaspellApi = () => {
             params.onComplete?.()
             trackTransferMetrics({
               transferParams: params,
-              txId: event.txHash?.toString(),
+              txId: hashToHex(event.txHash),
               senderAddress,
               sourceTokenUSDValue,
               destinationTokenUSDValue,
@@ -181,7 +181,7 @@ const useParaspellApi = () => {
             xcmTransferBuilderManager.disconnect(params)
           })
         } catch (error) {
-          handleSendError(params.sender, error, setStatus, event.txHash.toString())
+          handleSendError(params.sender, error, setStatus, hashToHex(event.txHash))
           xcmTransferBuilderManager.disconnect(params)
         }
       },
@@ -228,7 +228,7 @@ const useParaspellApi = () => {
     firstTransaction.tx.signSubmitAndWatch(polkadotSigner).subscribe({
       next: async (event: TxEvent) => {
         const transferToStore = {
-          id: event.txHash?.toString() ?? '',
+          id: hashToHex(event.txHash),
           sourceChain: params.sourceChain,
           sourceToken: params.sourceToken,
           destinationToken: params.destinationToken,
@@ -251,7 +251,7 @@ const useParaspellApi = () => {
             params.onComplete?.()
             trackTransferMetrics({
               transferParams: params,
-              txId: event.txHash?.toString(),
+              txId: hashToHex(event.txHash),
               senderAddress: account.address,
               sourceTokenUSDValue,
               destinationTokenUSDValue,
@@ -285,7 +285,7 @@ const useParaspellApi = () => {
       await addToOngoingTransfers(
         {
           ...transferToStore,
-          id: event.txHash.toString(),
+          id: hashToHex(event.txHash),
         },
         onComplete,
       )
@@ -298,7 +298,7 @@ const useParaspellApi = () => {
 
     addOrUpdate({
       ...transferToStore,
-      id: event.txHash.toString(),
+      id: hashToHex(event.txHash),
       crossChainMessageHash: messageHash,
       parachainMessageId: messageId,
       sourceChainExtrinsicIndex: extrinsicIndex,

--- a/app/src/utils/transfer.ts
+++ b/app/src/utils/transfer.ts
@@ -7,6 +7,7 @@ import {
   type TokenAmount,
 } from '@velocitylabs-org/turtle-registry'
 import { ethers, JsonRpcSigner } from 'ethers'
+import { toHex } from 'viem/utils'
 import type { Sender } from '@/hooks/useTransfer'
 import type { AmountInfo, CompletedTransfer, StoredTransfer, TransfersByDate } from '@/models/transfer'
 import { Direction, resolveDirection } from '@/services/transfer'
@@ -364,3 +365,5 @@ export const isSameChainSwap = <T extends SwapWithChains>(transfer: T): transfer
 export const isSwapWithTransfer = <T extends SwapWithChains>(transfer: T): transfer is T & CompleteSwap => {
   return isSwap(transfer) && !isSameChain(transfer.sourceChain, transfer.destChain)
 }
+
+export const hashToHex = (hash: string) => toHex(hash)

--- a/widget/src/hooks/useParaspellApi.tsx
+++ b/widget/src/hooks/useParaspellApi.tsx
@@ -20,7 +20,7 @@ import { getSenderAddress } from '@/utils/address'
 import { trackTransferMetrics, updateTransferMetrics } from '@/utils/analytics.ts'
 import { wait } from '@/utils/datetime'
 import { getExplorerLink } from '@/utils/explorer'
-import { isSameChainSwap, isSwapWithTransfer, txWasCancelled } from '@/utils/transfer'
+import { hashToHex, isSameChainSwap, isSwapWithTransfer, txWasCancelled } from '@/utils/transfer'
 import useCompletedTransfers from './useCompletedTransfers'
 import useNotification from './useNotification'
 import useOngoingTransfers from './useOngoingTransfers'
@@ -131,7 +131,7 @@ const useParaspellApi = () => {
     tx.signSubmitAndWatch(polkadotSigner).subscribe({
       next: async (event: TxEvent) => {
         const transferToStore = {
-          id: event.txHash?.toString() ?? '',
+          id: hashToHex(event.txHash),
           sourceChain: params.sourceChain,
           sourceToken: params.sourceToken,
           destinationToken: params.destinationToken,
@@ -151,7 +151,7 @@ const useParaspellApi = () => {
             params.onComplete?.()
             trackTransferMetrics({
               transferParams: params,
-              txId: event.txHash?.toString(),
+              txId: hashToHex(event.txHash),
               senderAddress,
               sourceTokenUSDValue,
               destinationTokenUSDValue,
@@ -207,7 +207,7 @@ const useParaspellApi = () => {
     firstTransaction.tx.signSubmitAndWatch(polkadotSigner).subscribe({
       next: async (event: TxEvent) => {
         const transferToStore = {
-          id: event.txHash?.toString() ?? '',
+          id: hashToHex(event.txHash),
           sourceChain: params.sourceChain,
           sourceToken: params.sourceToken,
           destinationToken: params.destinationToken,
@@ -230,7 +230,7 @@ const useParaspellApi = () => {
             params.onComplete?.()
             trackTransferMetrics({
               transferParams: params,
-              txId: event.txHash?.toString(),
+              txId: hashToHex(event.txHash),
               senderAddress: account.address,
               sourceTokenUSDValue,
               destinationTokenUSDValue,
@@ -240,7 +240,7 @@ const useParaspellApi = () => {
             xcmRouterBuilderManager.disconnect(params)
           })
         } catch (error) {
-          handleSendError(params.sender, error, setStatus, event.txHash?.toString())
+          handleSendError(params.sender, error, setStatus, hashToHex(event.txHash))
           xcmRouterBuilderManager.disconnect(params)
         }
       },

--- a/widget/src/utils/transfer.ts
+++ b/widget/src/utils/transfer.ts
@@ -1,5 +1,6 @@
 import type { Chain, Network, Token, TokenAmount } from '@velocitylabs-org/turtle-registry'
 import { ethers, JsonRpcSigner } from 'ethers'
+import { toHex } from 'viem'
 import type { Sender } from '@/hooks/useTransfer'
 import type { AmountInfo, StoredTransfer } from '@/models/transfer'
 import { isSameChain } from '@/utils/routes'
@@ -224,3 +225,5 @@ export const isSameChainSwap = <T extends SwapWithChains>(transfer: T): transfer
 export const isSwapWithTransfer = <T extends SwapWithChains>(transfer: T): transfer is T & CompleteSwap => {
   return isSwap(transfer) && !isSameChain(transfer.sourceChain, transfer.destChain)
 }
+
+export const hashToHex = (hash: string) => toHex(hash)


### PR DESCRIPTION
<!-- PR Title format: feat|fix|chore|refactor|test: short summary (e.g. feat: add aave snowbridge transfers) -->

## Description
After the recent PAPI version upgrade, the `txHash` is not correctly cast as a hex string but is registered as a Uint8Array.
This PR addresses it by leveraging `Viem.js` instead of PAPI, as it does not provide any direct helper. 

## Related Issue
🔥 Hotfix