### PR TITLE
Feat: Add recovery account for AssetHub refunds in multihop transfers

### DIFF
--- a/app/src/services/paraspell/xcmTransferBuilder.ts
+++ b/app/src/services/paraspell/xcmTransferBuilder.ts
@@ -10,6 +10,8 @@ import { toHuman } from '@/utils/transfer'
 
 type TxBuilder = ReturnType<typeof Builder>
 
+const velocityRecoveryAccount = '148FYcbxxTnhTCgiTgyVod5LygZZRQiGn2bQA2YqaaZbb9WJ'
+
 class XcmTransferBuilderManager {
   private static instance: XcmTransferBuilderManager
   private builders: Map<string, TxBuilder>
@@ -52,6 +54,9 @@ class XcmTransferBuilderManager {
         .currency({ ...currencyId, amount: sourceAmount })
         .address(recipient)
         .senderAddress(senderAddress)
+        // AssetHub refund address for multihop transfers (Mythos → Ethereum)
+        // Used when Key20 → ID32 conversion isn't possible, preventing fund loss on failed transfers
+        .ahAddress(velocityRecoveryAccount)
 
       this.builders.set(key, builder)
     } catch (error) {

--- a/widget/src/services/paraspell/xcmTransferBuilder.ts
+++ b/widget/src/services/paraspell/xcmTransferBuilder.ts
@@ -8,6 +8,8 @@ import type { TransferParams } from '@/hooks/useTransfer'
 import { getParaSpellChain, getParaspellToken } from '@/lib/paraspell/transfer'
 import { toHuman } from '@/utils/transfer'
 
+const velocityRecoveryAccount = '148FYcbxxTnhTCgiTgyVod5LygZZRQiGn2bQA2YqaaZbb9WJ'
+
 type TxBuilder = ReturnType<typeof Builder>
 
 class XcmTransferBuilderManager {
@@ -52,6 +54,9 @@ class XcmTransferBuilderManager {
         .currency({ ...currencyId, amount: sourceAmount })
         .address(recipient)
         .senderAddress(senderAddress)
+        // AssetHub refund address for multihop transfers (Mythos → Ethereum)
+        // Used when Key20 → ID32 conversion isn't possible, preventing fund loss on failed transfers
+        .ahAddress(velocityRecoveryAccount)
 
       this.builders.set(key, builder)
     } catch (error) {


### PR DESCRIPTION
If a transfer fails the refund should go to the provided ahAddress on AssetHub.

## Related Issue
https://linear.app/velocitylabs/issue/VEL-516/add-ahaddress-parameter-to-sdk-builder-for-assethub-refunds-in