### PR TITLE
feat: widget rely on history api route for SB tracking

### DIFF
--- a/.changeset/long-windows-help.md
+++ b/.changeset/long-windows-help.md
@@ -1,0 +1,5 @@
+---
+"@velocitylabs-org/turtle-widget": patch
+---
+
+refactor snowbridge tracking

--- a/widget/src/hooks/useOngoingTransfersTracker.ts
+++ b/widget/src/hooks/useOngoingTransfersTracker.ts
@@ -1,17 +1,15 @@
 import { TransferStatus } from '@snowbridge/api/dist/history'
 import { useQuery } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
-import { getSbEnvironment } from '@/lib/snowbridge'
 import { NotificationSeverity } from '@/models/notification'
-import { type CompletedTransfer, type StoredTransfer, TxStatus } from '@/models/transfer'
+import { type CompletedTransfer, type StoredTransfer, TxStatus, type TxTrackingResult } from '@/models/transfer'
 import { updateTransferMetrics } from '@/utils/analytics.ts'
 import { getExplorerLink } from '@/utils/explorer'
 import {
   findMatchingTransfer,
-  getFormattedOngoingTransfers,
+  formatTransfersWithDirection,
   getTransferStatus,
   isCompletedTransfer,
-  trackTransfers,
 } from '@/utils/tracking'
 import useCompletedTransfers from './useCompletedTransfers'
 import useNotification from './useNotification'
@@ -35,9 +33,16 @@ const useOngoingTransfersTracker = (ongoingTransfers: StoredTransfer[]) => {
   } = useQuery({
     queryKey: ['ongoing-transfers', ongoingTransfers.map(t => t.id)],
     queryFn: async () => {
-      const env = getSbEnvironment('Polkadot')
-      const formattedTransfers = getFormattedOngoingTransfers(ongoingTransfers)
-      return trackTransfers(env, formattedTransfers)
+      const formattedTransfers = formatTransfersWithDirection(ongoingTransfers)
+      // TODO: update `/api/history` endpoint
+      const response = await fetch(`/api/history`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ongoingTransfers: formattedTransfers }),
+      })
+      return (await response.json()) as TxTrackingResult[]
     },
     refetchInterval: REVALIDATE,
     staleTime: REVALIDATE,

--- a/widget/src/models/transfer.ts
+++ b/widget/src/models/transfer.ts
@@ -93,6 +93,7 @@ export interface OngoingTransferWithDirection extends RawTransfer {
 export interface OngoingTransfers {
   toEthereum: OngoingTransferWithDirection[] // AH => Eth transfer
   toPolkadot: OngoingTransferWithDirection[] // Eth => AH || Parachain transfer
+  withinPolkadot: OngoingTransferWithDirection[]
 }
 
 export enum TxStatus {


### PR DESCRIPTION
<!-- PR Title format: feat|fix|chore|refactor|test: short summary (e.g. feat: add aave snowbridge transfers) -->

## Description
Widget hooks compliance & SnowBridge tracking rely on the app history API route.

⚠️ fetch request endpoint must be updated when CORS issue are fixed.

## Related Issue
WIP - App migration to Widget