### PR TITLE
Fix: token price

### DIFF
--- a/widget/src/hooks/useTokenPrice.ts
+++ b/widget/src/hooks/useTokenPrice.ts
@@ -1,6 +1,7 @@
 import { captureException } from '@sentry/react'
 import { useQuery } from '@tanstack/react-query'
-import { getTokenPrice, type Token, type TokenPriceResult } from '@velocitylabs-org/turtle-registry'
+import type { Token, TokenPriceResult } from '@velocitylabs-org/turtle-registry'
+import { getCachedTokenPrice } from '@/services/balance.ts'
 import { CACHE_REVALIDATE_IN_SECONDS } from '@/utils/consts'
 
 const useTokenPrice = (token?: Token | null): TokenPriceResult => {
@@ -12,7 +13,7 @@ const useTokenPrice = (token?: Token | null): TokenPriceResult => {
     queryKey: ['tokenPrice', token?.id],
     queryFn: async () => {
       if (!token) return null
-      return await getTokenPrice(token)
+      return await getCachedTokenPrice(token)
     },
     staleTime: CACHE_REVALIDATE_IN_SECONDS * 1000, // specified in miliseconds
   })

--- a/widget/src/services/balance.ts
+++ b/widget/src/services/balance.ts
@@ -1,26 +1,56 @@
 import type { Token, TokenPrice } from '@velocitylabs-org/turtle-registry'
+import { getTokenPrice } from '@velocitylabs-org/turtle-registry'
+import { CACHE_REVALIDATE_IN_SECONDS } from '@/utils/consts.ts'
 
-export const CACHE_REVALIDATE_IN_SECONDS = 180
+interface CacheEntry {
+  data: TokenPrice
+  timestamp: number
+}
+
+const CACHE_NAME = 'token-price-cache-v1'
 
 /**
- * Fetches and caches the price of a token from the server.
+ * Fetches and caches the price of a token using the Cache API.
  * It serves as a cached layer for retrieving token prices by relying on the `getTokenPrice` function.
  *
  * @param token - The token to fetch its price.
  * @returns - A Promise resolving to the token price as a number.
  */
-export const getCachedTokenPrice = async (token: Token): Promise<TokenPrice> => {
-  const response = await fetch(`${globalThis.ENDPOINT_URL}api/token-price`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ token }),
-  })
+export const getCachedTokenPrice = async (token: Token): Promise<TokenPrice | null> => {
+  const cacheKey = `tokenPrice-${token.id}`
+  const now = Date.now()
 
-  if (!response.ok) {
-    const { error } = await response.json()
-    throw new Error(error || `Failed to fetch ${token.id} price from server request`)
+  try {
+    const cache = await caches.open(CACHE_NAME)
+    const cachedResponse = await cache.match(cacheKey)
+    if (cachedResponse) {
+      const cacheEntry: CacheEntry = await cachedResponse.json()
+      const cacheAge = (now - cacheEntry.timestamp) / 1000 // in seconds
+
+      if (cacheAge < CACHE_REVALIDATE_IN_SECONDS) {
+        return cacheEntry.data
+      }
+    }
+
+    // Cache miss or stale, fetch fresh data
+    const tokenPrice = await getTokenPrice(token)
+
+    if (tokenPrice) {
+      const cacheEntry: CacheEntry = {
+        data: tokenPrice,
+        timestamp: now,
+      }
+
+      const response = new Response(JSON.stringify(cacheEntry), {
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      await cache.put(cacheKey, response)
+    }
+
+    return tokenPrice
+  } catch {
+    // Fallback if Cache API is not available
+    return await getTokenPrice(token)
   }
-  return await response.json()
 }


### PR DESCRIPTION
This PR fixes the issue of obtaining the token price by calling it directly from the client side and caching it using the browser API. The endpoint was already handling this, so by implementing this change, we eliminate the need to maintain an endpoint in the app.
