### PR TITLE
fix: svgs & app storage

### DIFF
--- a/app/src/components/svg/ArrowRight.tsx
+++ b/app/src/components/svg/ArrowRight.tsx
@@ -13,8 +13,8 @@ export default function ArrowRight({ fill = colors['turtle-foreground'], ...prop
         clipRule="evenodd"
         d="M4 7.33334L8.66667 4M8.66667 4L4 0.666669M8.66667 4L1 4"
         stroke={fill}
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   )

--- a/app/src/components/svg/Cross.tsx
+++ b/app/src/components/svg/Cross.tsx
@@ -8,8 +8,8 @@ interface CrossProps extends ComponentPropsWithoutRef<'svg'> {
 export default function Cross({ stroke = colors['turtle-secondary'], ...props }: CrossProps) {
   return (
     <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-      <path d="M7.33331 0.666687L0.666647 7.33335" stroke={stroke} stroke-linecap="round" />
-      <path d="M0.666687 0.666687L7.33335 7.33335" stroke={stroke} stroke-linecap="round" />
+      <path d="M7.33331 0.666687L0.666647 7.33335" stroke={stroke} strokeLinecap="round" />
+      <path d="M0.666687 0.666687L7.33335 7.33335" stroke={stroke} strokeLinecap="round" />
     </svg>
   )
 }

--- a/app/src/components/svg/LoadingIcon.tsx
+++ b/app/src/components/svg/LoadingIcon.tsx
@@ -31,10 +31,10 @@ export default function LoadingIcon({
       <path
         d="M4.81081 1.61894C5.76664 1.03293 6.96543 0.829547 8.13794 1.15427C9.85203 1.62899 11.0011 3.09141 11.1173 4.72448V6.60038M9.20764 8.38106C8.2518 8.96707 7.05302 9.17045 5.88051 8.84573C4.0834 8.34802 2.90735 6.76461 2.8916 5.03713V3.78653"
         stroke={color}
-        stroke-linecap="round"
+        strokeLinecap="round"
       />
-      <path d="M1 5.53863L2.87053 3.6742L4.89315 5.53847" stroke={color} stroke-linecap="round" />
-      <path d="M13 5.00001L11.1295 6.86444L9.10685 5.00017" stroke={color} stroke-linecap="round" />
+      <path d="M1 5.53863L2.87053 3.6742L4.89315 5.53847" stroke={color} strokeLinecap="round" />
+      <path d="M13 5.00001L11.1295 6.86444L9.10685 5.00017" stroke={color} strokeLinecap="round" />
     </svg>
   )
 }

--- a/app/src/models/completed-transfer-schema.ts
+++ b/app/src/models/completed-transfer-schema.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod'
 import { TxStatus } from './transfer'
 
+const logoURISchema = z.string().or(z.object({}).passthrough())
+
 const looseChainSchema = z.object({
   uid: z.string(),
   name: z.string(),
-  logoURI: z.string(),
+  logoURI: logoURISchema,
   chainId: z.number(),
   network: z.enum(['Ethereum', 'Polkadot', 'Kusama', 'Arbitrum']),
 
@@ -18,7 +20,7 @@ const looseChainSchema = z.object({
 const looseTokenSchema = z.object({
   id: z.string(),
   name: z.string(),
-  logoURI: z.string(),
+  logoURI: logoURISchema,
   symbol: z.string(),
   decimals: z.number(),
   address: z.string().optional(),


### PR DESCRIPTION
<!-- PR Title format: feat|fix|chore|refactor|test: short summary (e.g. feat: add aave snowbridge transfers) -->

## Description
This PR fixes the Storage LogoURI issue when moving a Transfer from ongoing to completed. Currently, if the Transfer's LogoURI is an object and not a string, it does not match the Storage validation schema and gets filtered (& deleted). 

## Related Issue
Closes [VEL-543](https://linear.app/velocitylabs/issue/VEL-543/fix-turtle-storage-and-svg-errors)